### PR TITLE
proof of concept for "readable" class names

### DIFF
--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -6,15 +6,17 @@ class StyletronCore {
 
   /**
    * Create a new StyletronCore instance
-   * @param {object} [opts]           An object containing options
-   * @param {string} [opts.prefix=''] A prefix for generated CSS class names
+   * @param {object} [opts]                           An object containing options
+   * @param {string} [opts.prefix='']                 A prefix for generated CSS class names
+   * @param {boolean} [opts.readableClassNames=false] Use readable class names
    */
-  constructor({prefix = ''} = {}) {
+  constructor({prefix = '', readableClassNames = false} = {}) {
     this.cache = {
       media: {},
       pseudo: {}
     };
     this.prefix = prefix === '' ? false : prefix;
+    this.readableClassNames = readableClassNames;
     this.uniqueCount = 0;
     this.offset = 10; // skip 0-9
     this.msb = 35;
@@ -59,7 +61,8 @@ class StyletronCore {
       return cached;
     }
     const virtualCount = this.incrementVirtualCount();
-    const hash = virtualCount.toString(36);
+    const readableClassName = decl.prop + '-' + decl.val;
+    const hash = this.readableClassNames ? readableClassName : virtualCount.toString(36);
     const className = this.prefix ? this.prefix + hash : hash;
     StyletronCore.assignDecl(this.cache, decl, className);
     return className;

--- a/packages/styletron-core/src/test/index.js
+++ b/packages/styletron-core/src/test/index.js
@@ -56,3 +56,20 @@ test('test injection with prefix', t => {
   t.equal(instance.getCount(), 1, 'unique count incremented');
   t.end();
 });
+
+test('test injection with readable class names', t => {
+  const instance = new StyletronTest({readableClassNames: true});
+  t.equal(instance.readableClassNames, true, 'readableClassNames is set on instance');
+  t.equal(instance.getCount(), 0, 'starts with 0 declarations');
+  const decl1 = {prop: 'color', val: 'red'};
+  instance.injectDeclaration(decl1);
+  t.equal(instance.getCache().color.red, 'color-red');
+  t.equal(instance.getCachedDeclaration(decl1), 'color-red');
+  t.equal(instance.getCount(), 1, 'unique count incremented');
+  const decl2 = {prop: 'backgroundColor', val: 'orange'};
+  instance.injectDeclaration(decl2);
+  t.equal(instance.getCache().backgroundColor.orange, 'backgroundColor-orange');
+  t.equal(instance.getCachedDeclaration(decl2), 'backgroundColor-orange');
+  t.equal(instance.getCount(), 2, 'ends with 2 unique declarations');
+  t.end();
+});

--- a/packages/styletron-react/src/test/browser.js
+++ b/packages/styletron-react/src/test/browser.js
@@ -105,6 +105,20 @@ test('styled component', t => {
   t.end();
 });
 
+test('styled component with readable class names', t => {
+  const Widget = ({className}) => React.createElement('div', {className});
+  const SuperWidget = styled(Widget, {color: 'red'});
+  const styletron = new Styletron({readableClassNames: true});
+  const output = ReactTestUtils.renderIntoDocument(
+    React.createElement(Provider, {styletron},
+      React.createElement(SuperWidget))
+  );
+  const div = ReactTestUtils.findRenderedDOMComponentWithTag(output, 'div');
+  t.equal(div.className, 'color-red', 'matches expected styletron classes');
+  t.equal(styletron.getCss(), '.color-red{color:red}');
+  t.end();
+});
+
 test('innerRef works', t => {
   t.plan(1);
 


### PR DESCRIPTION
hola,

styletron is wonderful and at my company, we've been doing some internal demos as a potential option for introducing it into our codebase. some engineers though are concerned about the way the class names are named (they're simply hashes) so the readability goes out the door. this PoC introduces a new constructor option called `readableClassNames` (obviously this can be subject to rename), which will instead use a combination of `prefix + prop + val`, joined by hyphens, or `prop + val`, instead of letter hashes.

the naming concat would need to be a little more elegant, as you'll see in the screenshot where I'm rendering it in `react-storybook`

> without prefix

![screen shot 2017-03-02 at 2 06 33 pm](https://cloud.githubusercontent.com/assets/182661/23522635/c314d83e-ff51-11e6-89e9-012f24565e67.png)

> with prefix

![screen shot 2017-03-02 at 2 12 43 pm](https://cloud.githubusercontent.com/assets/182661/23522791/59115f42-ff52-11e6-8a6f-7d50e946eca2.png)


let me know your thoughts...