### PR TITLE
[WIP] Styletron Chrome DevTools extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
             "error",
             "never"
         ],
-        "consistent-return": "error",
+        "consistent-return": "off",
         "consistent-this": "error",
         "curly": "error",
         "default-case": "error",
@@ -193,7 +193,7 @@ module.exports = {
         "no-trailing-spaces": "off",
         "no-undef-init": "error",
         "no-undefined": "off",
-        "no-underscore-dangle": "error",
+        "no-underscore-dangle": "off",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unsafe-negation": "error",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "lerna": "2.0.0-beta.38",
-  "version": "2.5.3",
+  "version": "2.5.4-devtools.0",
   "npmClient": "yarn"
 }

--- a/packages/babel-plugin-styletron/package.json
+++ b/packages/babel-plugin-styletron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-styletron",
-  "version": "2.5.1",
+  "version": "2.5.4-devtools.0",
   "description": "Babel plugin for Styletron",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "homepage": "https://github.com/rtsao/styletron",

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "benchmarks",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.5.4-devtools.0",
   "description": "Benchmarks for styletron",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "run-series": "^1.1.4",
     "styletron-client": "^2.5.1",
     "styletron-server": "^2.5.1",
-    "styletron-utils": "^2.5.1"
+    "styletron-utils": "^2.5.4-devtools.0"
   },
   "devDependencies": {
     "glamor": "^2.17.14"

--- a/packages/chrome-devtools/devtools_page.html
+++ b/packages/chrome-devtools/devtools_page.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <script src="devtools_script.js"></script>
+  </body>
+</html>

--- a/packages/chrome-devtools/devtools_script.js
+++ b/packages/chrome-devtools/devtools_script.js
@@ -1,0 +1,14 @@
+const {panels, inspectedWindow} = window.chrome.devtools;
+const elementsPanel = panels.elements; 
+
+elementsPanel.createSidebarPane('Styletron', (sidebar) => {
+  elementsPanel.onSelectionChanged.addListener(() => {
+    inspectedWindow.eval("__STYLETRON_DEVTOOLS__.getStyles($0)", (res, err) => {
+      if (res) {
+        sidebar.setObject(res, 'Styletron Styles')
+      } else {
+        sidebar.setObject(null, 'Not a styled element');
+      }
+    });
+  });
+});

--- a/packages/chrome-devtools/manifest.json
+++ b/packages/chrome-devtools/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name":"styletron-devtools",
+  "version": "0.0.1",
+  "manifest_version": 2,
+  "description": "Inspect styletron styles",
+  "permissions": [],
+  "devtools_page": "devtools_page.html"
+}

--- a/packages/chrome-devtools/package.json
+++ b/packages/chrome-devtools/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "styletron-devtools",
+  "private": true,
+  "version": "2.5.3",
+  "description": "Inferno bindings for Styletron",
+  "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
+  "homepage": "https://github.com/rtsao/styletron",
+  "repository": "git@github.com:rtsao/styletron.git",
+  "bugs": "https://github.com/rtsao/styletron/issues",
+  "scripts": {},
+  "dependencies": {},
+  "peerDependencies": {},
+  "devDependencies": {},
+  "license": "MIT"
+}

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demos",
-  "version": "2.5.3",
+  "version": "2.5.4-devtools.0",
   "description": "A universal stylesheet manager for node.js and browsers",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "homepage": "https://github.com/rtsao/styletron",
@@ -20,9 +20,9 @@
     "connect": "^3.4.1",
     "serve-static": "^1.11.1",
     "styletron-client": "^2.5.1",
-    "styletron-react": "^2.5.3",
+    "styletron-react": "^2.5.4-devtools.0",
     "styletron-server": "^2.5.1",
-    "styletron-utils": "^2.5.1"
+    "styletron-utils": "^2.5.4-devtools.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/packages/styletron-inferno/package.json
+++ b/packages/styletron-inferno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styletron-inferno",
-  "version": "2.5.3",
+  "version": "2.5.4-devtools.0",
   "description": "Inferno bindings for Styletron",
   "author": "Matthew Wagerfield <matthew@wagerfield.com>",
   "homepage": "https://github.com/rtsao/styletron",
@@ -16,7 +16,7 @@
   "dependencies": {
     "styletron-client": "^2.5.1",
     "styletron-server": "^2.5.1",
-    "styletron-utils": "^2.5.1"
+    "styletron-utils": "^2.5.4-devtools.0"
   },
   "peerDependencies": {
     "inferno": "^1.3.1",

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styletron-react",
-  "version": "2.5.3",
+  "version": "2.5.4-devtools.0",
   "description": "Official React bindings for styletron",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "homepage": "https://github.com/rtsao/styletron",
@@ -18,7 +18,7 @@
     "@types/react": "*",
     "styletron-client": "^2.5.1",
     "styletron-server": "^2.5.1",
-    "styletron-utils": "^2.5.1"
+    "styletron-utils": "^2.5.4-devtools.0"
   },
   "peerDependencies": {
     "react": "0.14.x - 15.x"

--- a/packages/styletron-react/src/styled.js
+++ b/packages/styletron-react/src/styled.js
@@ -6,6 +6,18 @@ const isValidAttr = require('./is-valid-attr');
 const STYLES_KEY = '__STYLETRON_STYLES';
 const TAG_KEY = '__STYLETRON_TAG';
 
+if (typeof window !== 'undefined' && !window.__STYLETRON_DEVTOOLS__) {
+  const stylesMap = new WeakMap();
+  window.__STYLETRON_DEVTOOLS__ = {
+    stylesMap,
+    getStyles: (element) => {
+      if (stylesMap.has(element)) {
+        return stylesMap.get(element);
+      }
+    }
+  };
+}
+
 module.exports = styled;
 
 /**
@@ -86,6 +98,18 @@ function createStyledElementComponent(tagName, stylesArray) {
 
       if (this.props.innerRef) {
         elementProps.ref = this.props.innerRef;
+      }
+
+      if (typeof window !== 'undefined') {
+        const existingRef = elementProps.ref;
+        elementProps.ref = (element) => {
+          if (element) {
+            window.__STYLETRON_DEVTOOLS__.stylesMap.set(element, resolvedStyle);
+          }
+          if (existingRef) {
+            return existingRef(element);
+          }
+        };
       }
 
       return React.createElement(StyledElement[TAG_KEY], elementProps);

--- a/packages/styletron-utils/package.json
+++ b/packages/styletron-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styletron-utils",
-  "version": "2.5.1",
+  "version": "2.5.4-devtools.0",
   "description": "Generic helper utilities for Styletron",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "homepage": "https://github.com/rtsao/styletron",


### PR DESCRIPTION
This PR contains a WIP proof of concept for a Styletron Chrome DevTools extension.

It is currently a very basic sidebar pane that is added to the Elements panel. When you select an element that is a `styletron-react` styled element, the resolved Styletron style object will appear.

![screen shot 2017-04-04 at 6 05 00 pm](https://cloud.githubusercontent.com/assets/780408/24685262/44e0122e-1961-11e7-898b-ebd11d9f9c58.png)

I'm open to suggestions on what this should look like and which features there should be. Please comment with your ideas! The sidebar pane can contain arbitrary HTML/CSS/JS so it can be anything. Or it could even be a full panel (like the React DevTools extension).

A few initial ideas:
- When a styled element extends another styled element, show both the base style object and the overriding style object.
- Editing of style objects. This will probably be somewhat challenging.
- Also display a mapping of declarations to atomic class names

