### PR TITLE
Typed css properties

### DIFF
--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -35,6 +35,8 @@ declare namespace StyletronReact {
 
   type ClassNameProp = {className?: string};
 
+  type StyleProp<TProps> = {styleProps: TProps};
+
   export function core<TOuterProps, TInnerProps>(
     base: React.StatelessComponent<TInnerProps>,
     style: StyleArgument<TOuterProps>,

--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -7,29 +7,29 @@ import StyletronServer from "styletron-server";
 import StyletronClient from "styletron-client";
 
 declare namespace StyletronReact {
-  export class StyletronProvider extends React.Component<{styletron: StyletronServer | StyletronClient}, React.ComponentState> {}
+  class StyletronProvider extends React.Component<{styletron: StyletronServer | StyletronClient}, React.ComponentState> {}
 
-  export function styled<TProps>(
+  function styled<TProps>(
     base: React.StatelessComponent<TProps & ClassNameProp>,
     style: StyleArgument<TProps>): Component<TProps>;
 
-  export function styled<TInnerProps, TOuterProps>(
+  function styled<TInnerProps, TOuterProps>(
     base: React.StatelessComponent<TInnerProps & ClassNameProp>,
     style: StyleArgument<TOuterProps>): Component<TOuterProps & TInnerProps>;
 
-  export function styled<TProps, TComponent extends React.Component<TProps, React.ComponentState>>(
+  function styled<TProps, TComponent extends React.Component<TProps, React.ComponentState>>(
     base: React.ClassType<TProps, TComponent, React.ComponentClass<TProps & ClassNameProp>>,
     style: StyleArgument<TProps>): Component<ClassProps<TProps, TComponent>>;
 
-  export function styled<TProps, TBase extends keyof BasePropsMap<TProps>>(
+  function styled<TProps, TBase extends keyof BasePropsMap<TProps>>(
     base: TBase,
     style: StyleArgument<TProps>): Component<BasePropsMap<TProps>[TBase]>;
 
-  export function styled<TElement extends HTMLElement, TProps>(
+  function styled<TElement extends HTMLElement, TProps>(
     base: string,
     style: StyleArgument<TProps>): Component<HTMLProps<TProps, React.AllHTMLAttributes<TElement>, TElement>>;
 
-  export function styled<TElement extends SVGElement, TProps>(
+  function styled<TElement extends SVGElement, TProps>(
     base: string,
     style: StyleArgument<TProps>): Component<SVGProps<TProps, TElement>>;
 
@@ -37,27 +37,27 @@ declare namespace StyletronReact {
 
   type StyleProp<TProps> = {styleProps: TProps};
 
-  export function core<TOuterProps, TInnerProps>(
+  function core<TOuterProps, TInnerProps>(
     base: React.StatelessComponent<TInnerProps>,
     style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<TOuterProps>;
 
-  export function core<TOuterProps, TInnerProps, TComponent extends React.Component<TInnerProps, React.ComponentState>>(
+  function core<TOuterProps, TInnerProps, TComponent extends React.Component<TInnerProps, React.ComponentState>>(
     base: React.ClassType<TInnerProps, TComponent, React.ComponentClass<TInnerProps>>,
     style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<ClassProps<TOuterProps, TComponent>>;
 
-  export function core<TOuterProps, TInnerProps, TBase extends keyof BasePropsMap<TInnerProps>>(
+  function core<TOuterProps, TInnerProps, TBase extends keyof BasePropsMap<TInnerProps>>(
     base: TBase,
     style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<BasePropsMap<TOuterProps>[TBase]>;
 
-  export function core<TElement extends HTMLElement, TOuterProps, TInnerProps>(
+  function core<TElement extends HTMLElement, TOuterProps, TInnerProps>(
     base: string,
     style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<HTMLProps<TOuterProps, React.AllHTMLAttributes<TElement>, TElement>>;
 
-  export function core<TElement extends SVGElement, TOuterProps, TInnerProps>(
+  function core<TElement extends SVGElement, TOuterProps, TInnerProps>(
     base: string,
     style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<SVGProps<TOuterProps, TElement>>;

--- a/packages/styletron-react/index.d.ts
+++ b/packages/styletron-react/index.d.ts
@@ -2,6 +2,7 @@
 // TypeScript Version: 2.1
 
 import * as React from "react";
+import * as CSS from 'csstype';
 import StyletronServer from "styletron-server";
 import StyletronClient from "styletron-client";
 
@@ -10,53 +11,53 @@ declare namespace StyletronReact {
 
   export function styled<TProps>(
     base: React.StatelessComponent<TProps & ClassNameProp>,
-    style: Style<TProps>): Component<TProps>;
+    style: StyleArgument<TProps>): Component<TProps>;
 
   export function styled<TInnerProps, TOuterProps>(
     base: React.StatelessComponent<TInnerProps & ClassNameProp>,
-    style: Style<TOuterProps>): Component<TOuterProps & TInnerProps>;
+    style: StyleArgument<TOuterProps>): Component<TOuterProps & TInnerProps>;
 
   export function styled<TProps, TComponent extends React.Component<TProps, React.ComponentState>>(
     base: React.ClassType<TProps, TComponent, React.ComponentClass<TProps & ClassNameProp>>,
-    style: Style<TProps>): Component<ClassProps<TProps, TComponent>>;
+    style: StyleArgument<TProps>): Component<ClassProps<TProps, TComponent>>;
 
   export function styled<TProps, TBase extends keyof BasePropsMap<TProps>>(
     base: TBase,
-    style: Style<TProps>): Component<BasePropsMap<TProps>[TBase]>;
+    style: StyleArgument<TProps>): Component<BasePropsMap<TProps>[TBase]>;
 
   export function styled<TElement extends HTMLElement, TProps>(
     base: string,
-    style: Style<TProps>): Component<HTMLProps<TProps, React.AllHTMLAttributes<TElement>, TElement>>;
+    style: StyleArgument<TProps>): Component<HTMLProps<TProps, React.AllHTMLAttributes<TElement>, TElement>>;
 
   export function styled<TElement extends SVGElement, TProps>(
     base: string,
-    style: Style<TProps>): Component<SVGProps<TProps, TElement>>;
+    style: StyleArgument<TProps>): Component<SVGProps<TProps, TElement>>;
 
   type ClassNameProp = {className?: string};
 
   export function core<TOuterProps, TInnerProps>(
     base: React.StatelessComponent<TInnerProps>,
-    style: Style<TOuterProps>,
+    style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<TOuterProps>;
 
   export function core<TOuterProps, TInnerProps, TComponent extends React.Component<TInnerProps, React.ComponentState>>(
     base: React.ClassType<TInnerProps, TComponent, React.ComponentClass<TInnerProps>>,
-    style: Style<TOuterProps>,
+    style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<ClassProps<TOuterProps, TComponent>>;
 
   export function core<TOuterProps, TInnerProps, TBase extends keyof BasePropsMap<TInnerProps>>(
     base: TBase,
-    style: Style<TOuterProps>,
+    style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<BasePropsMap<TOuterProps>[TBase]>;
 
   export function core<TElement extends HTMLElement, TOuterProps, TInnerProps>(
     base: string,
-    style: Style<TOuterProps>,
+    style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<HTMLProps<TOuterProps, React.AllHTMLAttributes<TElement>, TElement>>;
 
   export function core<TElement extends SVGElement, TOuterProps, TInnerProps>(
     base: string,
-    style: Style<TOuterProps>,
+    style: StyleArgument<TOuterProps>,
     assignProps: AssignProps<TOuterProps, TInnerProps>): Component<SVGProps<TOuterProps, TElement>>;
 
   type Component<TProps> = React.StatelessComponent<TProps>;
@@ -71,13 +72,13 @@ declare namespace StyletronReact {
     innerRef?: React.Ref<TInstance>;
   };
 
-  type AssignProps<TOuterProps, TInnerProps> = (styletron: StyletronServer | StyletronClient, style: React.CSSProperties, props?: TOuterProps) => TInnerProps;
+  type AssignProps<TOuterProps, TInnerProps> = (styletron: StyletronServer | StyletronClient, style: CSS.Properties, props?: TOuterProps) => TInnerProps;
 
-  type Style<TProps> = React.CSSProperties | StyleFunction<TProps>;
+  type StyleArgument<TProps> = StyleType | StyleFunction<TProps>;
 
-  // Intersecting `CSSProperties` enables autocompletion for CSS properties as
-  // plain objects and not only for function return objects
-  type StyleFunction<TProps> = React.CSSProperties & ((props: TProps, context?: any) => React.CSSProperties);
+  type StyleType = CSS.Properties & {[P in CSS.Pseudos]?: CSS.Properties} & {[key: string]: any};
+
+  type StyleFunction<TProps> = ((props: TProps, context?: any) => StyleType);
 
   interface BasePropsMap<TProps> {
     a: HTMLProps<TProps, React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@types/react": "*",
+    "csstype": "*",
     "prop-types": "^15.5.8",
     "styletron-client": "^3.0.0-rc.1",
     "styletron-server": "^3.0.0-rc.1",

--- a/packages/styletron-react/typecheck.tsx
+++ b/packages/styletron-react/typecheck.tsx
@@ -4,7 +4,8 @@ import StyletronServer from 'styletron-server';
 import {
   core,
   styled,
-  StyletronProvider
+  StyletronProvider,
+  StyleProp,
 } from './';
 
 const provider1 = (
@@ -18,6 +19,10 @@ const provider2 = (
     <div />
   </StyletronProvider>
 );
+
+type StylePropType1 = StyleProp<{
+  prop: boolean;
+}>;
 
 type PropType1 = {
   prop1: boolean;
@@ -37,7 +42,6 @@ class StatefullComponent extends React.Component<PropType1, React.ComponentState
   }
 }
 
-
 const WithStyleObject = styled('button', {
   color: 'green',
   ':hover': {
@@ -48,49 +52,50 @@ const WithStyleObject = styled('button', {
   }
 });
 
+<WithStyleObject type="" innerRef={(el: HTMLButtonElement) => {}} />
 
-const StyledHtmlElement = styled('button', (props: PropType1) => ({}));
+const StyledHtmlElement = styled('button', (props: StylePropType1) => ({}));
 
-<StyledHtmlElement type="" prop1={false} innerRef={(el: HTMLButtonElement) => {}} />
+<StyledHtmlElement type="" styleProps={{prop: true}} innerRef={(el: HTMLButtonElement) => {}} />;
 
-const ComposedHtmlElement = styled(StyledHtmlElement, (props: PropType2) => ({}));
+const ComposedHtmlElement = styled(StyledHtmlElement, props => ({}));
 
-<ComposedHtmlElement type="" prop1={false} prop2={0} innerRef={(el: HTMLButtonElement) => {}} />
+<ComposedHtmlElement type="" styleProps={{prop: true}} innerRef={(el: HTMLButtonElement) => {}} />;
 
 
-const StyledSvgElement = styled('svg', (props: PropType1) => ({}));
+const StyledSvgElement = styled('svg', (props: StylePropType1) => ({}));
 
-<StyledSvgElement fill="" prop1={false} innerRef={(el: SVGElement) => {}} />
+<StyledSvgElement fill="" styleProps={{prop: true}} innerRef={(el: SVGElement) => {}} />;
 
-const ComposedSvgElement = styled(StyledSvgElement, (props: PropType2) => ({}));
+const ComposedSvgElement = styled(StyledSvgElement, props => ({}));
 
-<ComposedSvgElement fill="" prop1={false} prop2={0} innerRef={(el: SVGElement) => {}} />
+<ComposedSvgElement fill="" styleProps={{prop: true}} innerRef={(el: SVGElement) => {}} />;
 
 
 const StyledStatelessComponentWithStyleFunc = styled(StatelessComponent, (props: PropType1) => ({}));
 
-<StyledStatelessComponentWithStyleFunc prop1={false} />
+<StyledStatelessComponentWithStyleFunc prop1={false} />;
 
 const StyledStatelessComponentWithStyleObject = styled(StatelessComponent, {});
 
-<StyledStatelessComponentWithStyleObject prop1={false} />
+<StyledStatelessComponentWithStyleObject prop1={false} />;
 
 const ComposedStatelessComponent = styled(StyledStatelessComponentWithStyleFunc, {});
 
-<ComposedStatelessComponent prop1={false} />
+<ComposedStatelessComponent prop1={false} />;
 
 
 const StyledStatefullComponentWithStyleFunc = styled(StatefullComponent, (props: PropType1) => ({}));
 
-<StyledStatefullComponentWithStyleFunc prop1={false} innerRef={(c: StatefullComponent) => {}} />
+<StyledStatefullComponentWithStyleFunc prop1={false} innerRef={(c: StatefullComponent) => {}} />;
 
 const StyledStatefullComponentWithStyleObject = styled(StatefullComponent, {});
 
-<StyledStatefullComponentWithStyleObject prop1={false} innerRef={(c: StatefullComponent) => {}} />
+<StyledStatefullComponentWithStyleObject prop1={false} innerRef={(c: StatefullComponent) => {}} />;
 
 const ComposedStatefullComponent = styled(StyledStatefullComponentWithStyleFunc, {});
 
-<ComposedStatefullComponent prop1={false} innerRef={(c: StatefullComponent) => {}} />
+<ComposedStatefullComponent prop1={false} innerRef={(c: StatefullComponent) => {}} />;
 
 
 const PrettyHTMLElement = core(
@@ -99,7 +104,7 @@ const PrettyHTMLElement = core(
   (styletron, styleResult, ownProps: PropType1) => ({...ownProps, className: ''})
 );
 
-<PrettyHTMLElement type="" prop1={false} innerRef={(el: HTMLButtonElement) => {}} />
+<PrettyHTMLElement type="" prop1={false} innerRef={(el: HTMLButtonElement) => {}} />;
 
 const PrettySVGElement = core(
   'svg',
@@ -107,7 +112,7 @@ const PrettySVGElement = core(
   (styletron, styleResult, ownProps: PropType1) => ({...ownProps, className: ''})
 );
 
-<PrettySVGElement type="" prop1={false} innerRef={(el: SVGElement) => {}} />
+<PrettySVGElement type="" prop1={false} innerRef={(el: SVGElement) => {}} />;
 
 const PrettyStatelessComponentWithStyleFunc = core(
   StatelessComponent,
@@ -115,7 +120,7 @@ const PrettyStatelessComponentWithStyleFunc = core(
   (styletron, styleResult, ownProps: PropType1) => ({...ownProps, className: ''})
 );
 
-<PrettyStatelessComponentWithStyleFunc prop1={false} />
+<PrettyStatelessComponentWithStyleFunc prop1={false} />;
 
 const PrettyStatelessComponentWithStyleObject = core(
   StatelessComponent,
@@ -123,7 +128,7 @@ const PrettyStatelessComponentWithStyleObject = core(
   (styletron, styleResult, ownProps: PropType1) => ({...ownProps, className: ''})
 );
 
-<PrettyStatelessComponentWithStyleObject prop1={false} />
+<PrettyStatelessComponentWithStyleObject prop1={false} />;
 
 const PrettyStatefullComponentWithStyleFunc = core(
   StatefullComponent,
@@ -131,7 +136,7 @@ const PrettyStatefullComponentWithStyleFunc = core(
   (styletron, styleResult, ownProps: PropType1) => ({...ownProps, className: ''})
 );
 
-<PrettyStatefullComponentWithStyleFunc prop1={false} />
+<PrettyStatefullComponentWithStyleFunc prop1={false} />;
 
 const PrettyStatefullComponentWithStyleObject = core(
   StatefullComponent,
@@ -139,7 +144,7 @@ const PrettyStatefullComponentWithStyleObject = core(
   (styletron, styleResult, ownProps: PropType1) => ({...ownProps, className: ''})
 );
 
-<PrettyStatefullComponentWithStyleObject prop1={false} />
+<PrettyStatefullComponentWithStyleObject prop1={false} />;
 
 
 const EmittingPropStatelessComponentWithStyleFunc = core(
@@ -148,7 +153,7 @@ const EmittingPropStatelessComponentWithStyleFunc = core(
   (styletron, styleResult, {prop2, ...restProps}: PropType1 & PropType2) => ({...restProps, className: ''})
 );
 
-<EmittingPropStatelessComponentWithStyleFunc prop1={false} prop2={0} />
+<EmittingPropStatelessComponentWithStyleFunc prop1={false} prop2={0} />;
 
 const EmittingPropStatelessComponentWithStyleObject = core(
   StatelessComponent,
@@ -156,7 +161,7 @@ const EmittingPropStatelessComponentWithStyleObject = core(
   (styletron, styleResult, {prop2, ...restProps}: PropType1 & PropType2) => ({...restProps, className: ''})
 );
 
-<EmittingPropStatelessComponentWithStyleObject prop1={false} prop2={0} />
+<EmittingPropStatelessComponentWithStyleObject prop1={false} prop2={0} />;
 
 const EmittingPropStatefullComponentWithStyleFunc = core(
   StatefullComponent,
@@ -164,7 +169,7 @@ const EmittingPropStatefullComponentWithStyleFunc = core(
   (styletron, styleResult, {prop2, ...restProps}: PropType1 & PropType2) => ({...restProps, className: ''})
 );
 
-<EmittingPropStatefullComponentWithStyleFunc prop1={false} prop2={0} />
+<EmittingPropStatefullComponentWithStyleFunc prop1={false} prop2={0} />;
 
 const EmittingPropStatefullComponentWithStyleObject = core(
   StatefullComponent,
@@ -172,4 +177,4 @@ const EmittingPropStatefullComponentWithStyleObject = core(
   (styletron, styleResult, {prop2, ...restProps}: PropType1 & PropType2) => ({...restProps, className: ''})
 );
 
-<EmittingPropStatefullComponentWithStyleObject prop1={false} prop2={0} />
+<EmittingPropStatefullComponentWithStyleObject prop1={false} prop2={0} />;

--- a/packages/styletron-react/yarn.lock
+++ b/packages/styletron-react/yarn.lock
@@ -685,6 +685,10 @@ css-in-js-utils@^1.0.3:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+csstype@*:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-1.1.0.tgz#504fe0cb1b2ede48373beb42fa65255b2ae17828"
+
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"


### PR DESCRIPTION
Replaces `React.CSSProperties` with `csstype`. These covers CSS3 psuedo styles like
```ts
{
  color: 'white',
  '::before': {
    display: 'inline-block',
  }
}
```

The problem is still custom `@media` style where you'll have to explicitly type it until TypeScript has solved the misinterpretation of key value types:

```ts
import {StyleType} from 'styletron-react';

const Pretty = styled(div, () => {
  const media: StyleType = {
    color: 'purple',
  };
  return {
    color: 'pink',
    '@media (min-width: 768px)': media,
  }
});
```

Added a type for the `styleProps`-property of `styled` but there's no way to type additions to that property when composing until TypeScript [rest types](https://github.com/Microsoft/TypeScript/pull/13470) has been released.