### PR TITLE
styletron-react: better composition

### DIFF
--- a/packages/styletron-client/src/index.js
+++ b/packages/styletron-client/src/index.js
@@ -60,7 +60,8 @@ class StyletronClient extends StyletronCore {
           pseudo: decl[2],
           media,
         },
-        decl[1]
+        decl[1],
+        this.declarations
       );
     }
   }

--- a/packages/styletron-core/src/__tests__/index.js
+++ b/packages/styletron-core/src/__tests__/index.js
@@ -22,6 +22,12 @@ test('test injection', t => {
   instance.injectDeclaration(decl1);
   t.equal(instance.getCache()['color:red'], 'a');
   t.equal(instance.getCachedDeclaration({block: 'color:red'}), 'a');
+  let media, pseudo;
+  t.deepEqual(instance.getDeclarationFromClassName('a'), {
+    block: 'color:red',
+    media,
+    pseudo,
+  });
   t.equal(instance.getCount(), 1, 'unique count incremented');
   instance.injectDeclaration(decl1);
   t.equal(
@@ -115,6 +121,7 @@ test('test injection with prefix', t => {
   instance.injectRawDeclaration(decl1);
   t.equal(instance.getCache()[block1], 'qqa');
   t.equal(instance.getCachedDeclaration(decl1), 'qqa');
+  t.deepEqual(instance.getDeclarationFromClassName('qqa'), decl1);
   t.equal(instance.getCount(), 1, 'unique count incremented');
   t.end();
 });

--- a/packages/styletron-core/src/index.js
+++ b/packages/styletron-core/src/index.js
@@ -13,6 +13,7 @@ class StyletronCore {
       media: {},
       pseudo: {},
     };
+    this.declarations = {};
     this.prefix = prefix === '' ? false : prefix;
     this.uniqueCount = 0;
     this.offset = 10; // skip 0-9
@@ -20,7 +21,7 @@ class StyletronCore {
     this.power = 1;
   }
 
-  static assignDecl(target, decl, className) {
+  static assignDecl(target, decl, className, declarations) {
     const {block, media, pseudo} = decl;
     let targetEntry;
     if (media) {
@@ -38,6 +39,7 @@ class StyletronCore {
       targetEntry = targetEntry.pseudo[pseudo];
     }
     targetEntry[block] = className;
+    declarations[className] = decl;
   }
 
   /**
@@ -69,7 +71,7 @@ class StyletronCore {
     const virtualCount = this.incrementVirtualCount();
     const hash = virtualCount.toString(36);
     const className = this.prefix ? this.prefix + hash : hash;
-    StyletronCore.assignDecl(this.cache, decl, className);
+    StyletronCore.assignDecl(this.cache, decl, className, this.declarations);
     return className;
   }
 
@@ -115,6 +117,15 @@ class StyletronCore {
       }
     }
     return entry[block];
+  }
+
+  /**
+   * Gets the declaration from a class name
+   * @param  {string}               The class name for the declaration
+   * @return {decl|undefined}       The CSS declaration object
+   */
+  getDeclarationFromClassName(className) {
+    return this.declarations[className];
   }
 }
 

--- a/packages/styletron-react/src/__tests__/browser.js
+++ b/packages/styletron-react/src/__tests__/browser.js
@@ -81,6 +81,113 @@ test('core applies styles', t => {
   t.end();
 });
 
+test('composition works with intermediate componenents', t => {
+  const Widget = styled('p', {color: 'red'});
+
+  const SuperWidget = styled(props => React.createElement(Widget, props), {
+    color: 'green',
+  });
+
+  const styletron = new Styletron();
+  const output = ReactTestUtils.renderIntoDocument(
+    React.createElement(
+      Provider,
+      {styletron},
+      React.createElement('div', {}, [
+        React.createElement(SuperWidget),
+        React.createElement(Widget),
+      ])
+    )
+  );
+  const [superWidget, widget] = ReactTestUtils.scryRenderedDOMComponentsWithTag(
+    output,
+    'p'
+  );
+  t.equal(superWidget.className, 'a', 'styletron classes');
+  t.equal(widget.className, 'b', 'styletron classes');
+  t.equal(styletron.getCss(), '.a{color:green}.b{color:red}');
+  t.end();
+});
+
+test('composition works with intermediate componenents: media', t => {
+  const Widget = styled('p', {
+    border: '1px solid black',
+    color: 'red',
+    '@media screen and (min-width: 1000px)': {
+      color: 'red',
+      border: 'none',
+    },
+  });
+
+  const SuperWidget = styled(props => React.createElement(Widget, props), {
+    color: 'green',
+    '@media screen and (min-width: 1000px)': {
+      color: 'green',
+    },
+  });
+
+  const styletron = new Styletron();
+  const output = ReactTestUtils.renderIntoDocument(
+    React.createElement(
+      Provider,
+      {styletron},
+      React.createElement('div', {}, [
+        React.createElement(SuperWidget),
+        React.createElement(Widget),
+      ])
+    )
+  );
+  const [superWidget, widget] = ReactTestUtils.scryRenderedDOMComponentsWithTag(
+    output,
+    'p'
+  );
+  t.equal(superWidget.className, 'c a b d', 'styletron classes');
+  t.equal(widget.className, 'c e f d', 'styletron classes');
+  t.equal(
+    styletron.getCss(),
+    '.a{color:green}.c{border:1px solid black}.e{color:red}@media screen and (min-width: 1000px){.b{color:green}.d{border:none}.f{color:red}}'
+  );
+  t.end();
+});
+
+test('composition works with intermediate componenents: pseudo', t => {
+  const Widget = styled('p', {
+    ':hover': {
+      color: 'red',
+      border: 'none',
+    },
+  });
+
+  const SuperWidget = styled(props => React.createElement(Widget, props), {
+    ':hover': {
+      color: 'green',
+    },
+  });
+
+  const styletron = new Styletron();
+  const output = ReactTestUtils.renderIntoDocument(
+    React.createElement(
+      Provider,
+      {styletron},
+      React.createElement('div', {}, [
+        React.createElement(SuperWidget),
+        React.createElement(Widget),
+      ])
+    )
+  );
+  const [superWidget, widget] = ReactTestUtils.scryRenderedDOMComponentsWithTag(
+    output,
+    'p'
+  );
+  t.equal(superWidget.className, 'a b', 'styletron classes');
+  t.equal(widget.className, 'c b', 'styletron classes');
+  t.equal(
+    styletron.getCss(),
+    '.a:hover{color:green}.b:hover{border:none}.c:hover{color:red}'
+  );
+  t.end();
+});
+
 test('core applies static styles', t => {
   const Widget = core('div', {color: 'red'}, strictAssignProps);
   const styletron = new Styletron();

--- a/packages/styletron-react/src/assign.js
+++ b/packages/styletron-react/src/assign.js
@@ -1,0 +1,12 @@
+export default function assign(target, source) {
+  for (const key in source) {
+    const val = source[key];
+    if (typeof val === 'object') {
+      target[key] = target[key] || {};
+      target[key] = Object.assign(target[key], val);
+    } else {
+      target[key] = val;
+    }
+  }
+  return target;
+}

--- a/packages/styletron-react/src/core.js
+++ b/packages/styletron-react/src/core.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import assign from './assign';
 
 const STYLETRON_KEY = '__STYLETRON';
 
@@ -27,7 +28,7 @@ export default function core(base, style, assignProps) {
 
 function createStyledElementComponent(base, stylesArray, assignProps) {
   function StyledElement(props, context) {
-    const ownProps = assign({}, props);
+    const ownProps = Object.assign({}, props);
     delete ownProps.innerRef;
 
     const styleResult = {};
@@ -65,13 +66,6 @@ function createStyledElementComponent(base, stylesArray, assignProps) {
   }
 
   return StyledElement;
-}
-
-function assign(target, source) {
-  for (const key in source) {
-    target[key] = source[key];
-  }
-  return target;
 }
 
 function omit$Props(source) {


### PR DESCRIPTION
Hi and thanks for this project... I love it!

So this PR attempts to solve 2 different problems that you probably didn't know that `styletron-react` had... 😄  Lets see if I can convince you 😬 

Lets start with the "silly/easy" one, let me explain it with one example:

```jsx
import {styled} from 'styletron-react';

const Panel = styled('div', {
  ':hover': {
    fontWeight: 'bold',
    color: 'blue',
  },
  fontSize: '12px'
});

const DeluxPanel = styled(Panel, {
  ':hover': {
    color: 'red',
  }
)
```

It would be nice if `DeluxPanel` on hover was red **and** bold. With the current implementation it will be only "red" (and not "bold"). Same issue happened with media-queries, basically that the objects were being replaced rather than merged.

Now lets have a look at the second improvement. This one is a bit tougher to explain, but it fixes issue #161 and IMHO it will be 100% necessary if we ever go down the path of #174. Again, let me explain it with some examples.

Lets say that I have a Currency component: that looks like this:

```jsx
import {connect} from 'react-redux';
import {injectIntl} from 'react-intl';
import {styled} from 'styletron-react';
import {compose, mapProps, setDisplayName} from 'recompose';

const enhancer = compose(
  setDisplayName('Currency'),
  injectIntl,
  connect(({currency}) => ({currency}), {}),
  mapProps(({currency, intl, children, ...rest}) => ({
    children: intl.formatNumber(children, {style: 'currency', currency}),
    ...rest,
  })
);

const Currency = enhancer(styled('span', {
  color: 'blue',
  textSize: '1em',
}));

Currency.propTypes = {
  children: PropTypes.number.isRequired,
};

export default Currency;
```

I can use my "awesome" `Currency` component like this `<Currency>5</Currency>` and it will display the number formatted with the currency that the user has selected.

Lets say that somewhere else I need to have a `BigCurrency` component, and I don't want to add another prop to the `Currency` component (just for the sake of argument). Basically, I would like to be able to do something like this:

```jsx
const BigCurrency = styled(Currency, {textSize: '2em'});
```

However, with the current implementation that won't work: because the `span` will receive both classes: the class of `textSize: 1em` and the class of `textSize: 2em`. So, what class will take over? It's a lottery.

If this PR gets merged, then `BigCurrency` will generate a `span` that will only receive the class of `textSize: 2em` and not the other, which I think it's awesome!

I'm well aware that I wouldn't have had this issue if I had implemented the `Currency` component like this:

```jsx
import {connect} from 'react-redux';
import {injectIntl} from 'react-intl';
import {styled} from 'styletron-react';
import {compose, mapProps, setDisplayName} from 'recompose';

const CurrencySpan = compose(
  setDisplayName('Currency'),
  connect(({currency}) => ({currency}), {}),
  injectIntl,
  mapProps(({currency, intl, children, ...rest}) => ({
    children: intl.formatNumber(children, {style: 'currency', currency}),
    ...rest,
  })
)('span');

const Currency = styled(CurrencySpan, {
  color: 'blue',
  textSize: '1em',
}));

Currency.propTypes = {
  children: PropTypes.number.isRequired,
};

export default Currency;
```

So, maybe this is not the best example, but before I jump into a -perhaps- more compelling example. I do want to point out that it's a pity that `styled` doesn't behave well with "normal" HOC composition.

Let me try with a hopefully more compelling example:

```jsx
import React from 'react';
import {styled} from 'styletron-react';

const Wrapper = styled('div', {
  border: '1px solid black',
  padding: '0.3 em',
});

const Title = styled('div', {
  fontSize: '1.2 em',
  color: 'grey',
});

const TitleBox = ({title, children, ...props}) => (
  <Wrapper {...props} >
    <Title>{title}</Title>
    {children}
  </Wrapper>
);

export default TitleBox;
```

Wouldn't it be nice to be able to do this?

```jsx
const DashedTitleBox = styled(TitleBox, {
  border: '1px dashed black',
});
```

With the current implementation `DashedTitleBox` will receive both "border" classes... It would be nice if it only received the "dashed" one.

## Full disclosure:

The problem that I have is that I don't used `styled` directly, I use my "own" version that looks (more or less) like this:

```js
import {styled} from 'styletron-react'
export default fnOrObj => Component => styled(Component, fnOrObj);
```

Because to me the styletron `styled` fn is a HOC (it's a function that takes a component as an argument and returns an enhanced one), and since I want to be able to compose it like the rest of HOCs, I've "flipped" and "curried" it...  However, as you can imagine, with the current implementation that makes my life quite miserable.