### PR TITLE
Add incorrect composition warning in dev

### DIFF
--- a/packages/styletron-react-core/src/index.js
+++ b/packages/styletron-react-core/src/index.js
@@ -161,6 +161,19 @@ export function createStyled<Style: Object, Engine>({
     base: Base,
     styleArg: styleArgT<Style, Props>,
   ): styletronComponentT<Style, Props, Base, Engine> {
+    if (__DEV__) {
+      if ((base: any).__STYLETRON__) {
+        /* eslint-disable no-console */
+        console.warn(
+          "It appears you are passing a styled component into `styled`.",
+        );
+        console.warn(
+          "For composition with existing styled components, use `withStyle`, `withStyleDeep`, or `withTransform` instead.",
+        );
+        /* eslint-enable no-console */
+      }
+    }
+
     const baseStyletron: styletronT<Style, {}, Base, Engine> = {
       reducers: [],
       // TODO: use typed generic instead of coercion once


### PR DESCRIPTION
The old styletron had a polymorphic styled function which was used for both lifting a base component into a styled component as well as composing existing components.

This adds a warning in development if this is detected, which will yield unexpected results