### PR TITLE
Skip object prototypes when serializing keyframes

### DIFF
--- a/packages/styletron-engine-atomic/src/css.js
+++ b/packages/styletron-engine-atomic/src/css.js
@@ -1,5 +1,7 @@
 // @flow strict
 
+declare var __DEV__: boolean;
+
 import hyphenate from "./hyphenate-style-name.js";
 
 export function atomicSelector(id: string, pseudo: string): string {
@@ -11,10 +13,19 @@ export function atomicSelector(id: string, pseudo: string): string {
 }
 
 export function keyframesToBlock(keyframes: Object): string {
+  if (__DEV__ && typeof Object.getPrototypeOf(keyframes) !== "undefined") {
+    if (Object.getPrototypeOf(keyframes) !== Object.getPrototypeOf({})) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Only plain objects should be used as animation values. Unexpectedly recieved:",
+        keyframes,
+      );
+    }
+  }
   let result = "";
-  for (const thing in keyframes) {
-    if (Object.prototype.hasOwnProperty.call(keyframes, thing)) {
-      result += `${thing}{${declarationsToBlock(keyframes[thing])}}`;
+  for (const prop in keyframes) {
+    if (Object.prototype.hasOwnProperty.call(keyframes, prop)) {
+      result += `${prop}{${declarationsToBlock(keyframes[prop])}}`;
     }
   }
   return result;

--- a/packages/styletron-engine-atomic/src/css.js
+++ b/packages/styletron-engine-atomic/src/css.js
@@ -13,7 +13,9 @@ export function atomicSelector(id: string, pseudo: string): string {
 export function keyframesToBlock(keyframes: Object): string {
   let result = "";
   for (const thing in keyframes) {
-    result += `${thing}{${declarationsToBlock(keyframes[thing])}}`;
+    if (Object.prototype.hasOwnProperty.call(keyframes, thing)) {
+      result += `${thing}{${declarationsToBlock(keyframes[thing])}}`;
+    }
   }
   return result;
 }

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -158,12 +158,12 @@ function injectFixtureStyles(styletron) {
 
 function injectFixtureKeyframes(styletron) {
   const Keyframes = function Keyframes() {};
-  Keyframes.prototype.someProperty = 'not-serialized';
+  Keyframes.prototype.someProperty = "not-serialized";
 
   const keyframeInstance = new Keyframes();
-  keyframeInstance.from = {color: 'purple'};
-  keyframeInstance['50%'] = {color: 'yellow'};
-  keyframeInstance.to = {color: 'orange'};
+  keyframeInstance.from = {color: "purple"};
+  keyframeInstance["50%"] = {color: "yellow"};
+  keyframeInstance.to = {color: "orange"};
 
   return styletron.renderKeyframes(keyframeInstance);
 }

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -156,16 +156,38 @@ function injectFixtureStyles(styletron) {
   });
 }
 
+test("non-pojo animation value", t => {
+  const styletron = new Styletron();
+
+  function Foo() {}
+  Foo.prototype.bar = "should not be serialized";
+  const foo = new Foo();
+  foo.from = {color: "purple"};
+  foo["50%"] = {color: "yellow"};
+  foo.to = {color: "orange"};
+
+  styletron.renderKeyframes(foo);
+
+  t.equal(
+    styletron.getCss(),
+    "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
+  );
+
+  t.end();
+});
+
 function injectFixtureKeyframes(styletron) {
-  const Keyframes = function Keyframes() {};
-  Keyframes.prototype.someProperty = "not-serialized";
-
-  const keyframeInstance = new Keyframes();
-  keyframeInstance.from = {color: "purple"};
-  keyframeInstance["50%"] = {color: "yellow"};
-  keyframeInstance.to = {color: "orange"};
-
-  return styletron.renderKeyframes(keyframeInstance);
+  return styletron.renderKeyframes({
+    from: {
+      color: "purple",
+    },
+    "50%": {
+      color: "yellow",
+    },
+    to: {
+      color: "orange",
+    },
+  });
 }
 
 function injectFixtureFontFace(styletron) {

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -157,17 +157,15 @@ function injectFixtureStyles(styletron) {
 }
 
 function injectFixtureKeyframes(styletron) {
-  return styletron.renderKeyframes({
-    from: {
-      color: "purple",
-    },
-    "50%": {
-      color: "yellow",
-    },
-    to: {
-      color: "orange",
-    },
-  });
+  const Keyframes = function Keyframes() {};
+  Keyframes.prototype.someProperty = 'not-serialized';
+
+  const keyframeInstance = new Keyframes();
+  keyframeInstance.from = {color: 'purple'};
+  keyframeInstance['50%'] = {color: 'yellow'};
+  keyframeInstance.to = {color: 'orange'};
+
+  return styletron.renderKeyframes(keyframeInstance);
 }
 
 function injectFixtureFontFace(styletron) {


### PR DESCRIPTION
This change fixes a bug in `keyframesToBlock` that was causing properties on the prototype to be serialized in a tag.