### PR TITLE
Catch errors from invalid/unprefixed rules

### DIFF
--- a/packages/styletron-engine-atomic/src/client/client.js
+++ b/packages/styletron-engine-atomic/src/client/client.js
@@ -78,10 +78,17 @@ class StyletronClient implements StandardEngine {
     const onNewStyle = (cache, id, value) => {
       const {pseudo, block} = value;
       const sheet: CSSStyleSheet = (this.styleElements[cache.key].sheet: any);
-      sheet.insertRule(
-        styleBlockToRule(atomicSelector(id, pseudo), block),
-        sheet.cssRules.length,
-      );
+      const rule = styleBlockToRule(atomicSelector(id, pseudo), block);
+      try {
+        sheet.insertRule(rule, sheet.cssRules.length);
+      } catch (e) {
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Failed to inject CSS: "${rule}". Perhaps this has invalid or un-prefixed properties?`,
+          );
+        }
+      }
     };
 
     // Setup style cache
@@ -101,10 +108,17 @@ class StyletronClient implements StandardEngine {
       (cache, id, value) => {
         this.styleCache.getCache("");
         const sheet: CSSStyleSheet = (this.styleElements[""].sheet: any);
-        sheet.insertRule(
-          keyframesBlockToRule(id, keyframesToBlock(value)),
-          sheet.cssRules.length,
-        );
+        const rule = keyframesBlockToRule(id, keyframesToBlock(value));
+        try {
+          sheet.insertRule(rule, sheet.cssRules.length);
+        } catch (e) {
+          if (__DEV__) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Failed to inject CSS: "${rule}". Perhaps this has invalid or un-prefixed properties?`,
+            );
+          }
+        }
       },
     );
 
@@ -113,10 +127,17 @@ class StyletronClient implements StandardEngine {
       (cache, id, value) => {
         this.styleCache.getCache("");
         const sheet: CSSStyleSheet = (this.styleElements[""].sheet: any);
-        sheet.insertRule(
-          fontFaceBlockToRule(id, declarationsToBlock(value)),
-          sheet.cssRules.length,
-        );
+        const rule = fontFaceBlockToRule(id, declarationsToBlock(value));
+        try {
+          sheet.insertRule(rule, sheet.cssRules.length);
+        } catch (e) {
+          if (__DEV__) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Failed to inject CSS: "${rule}". Perhaps this has invalid or un-prefixed properties?`,
+            );
+          }
+        }
       },
     );
 


### PR DESCRIPTION
The current vendor prefixing library doesn't support old browsers such as Android 4.4 (i.e. keyframes are unprefixed) which can cause errors to be thrown by `insertRule`.

By wrapping this in a try/catch block, we allow for graceful degradation of these rules.