### PR TITLE
Fix createStyled wrapper and add test

### DIFF
--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -116,11 +116,7 @@ test("withStyle (dynamic)", t => {
     <Provider
       value={{
         renderStyle: x => {
-          t.deepEqual(x, {
-            color: "red",
-            background: "green",
-            fontSize: "14px",
-          });
+          t.deepEqual(x, {color: "red", background: "green", fontSize: "14px"});
           return "";
         },
         renderKeyframes: () => "",
@@ -517,7 +513,7 @@ test("keyframes injection", t => {
   t.end();
 });
 
-test.only("createStyled wrapper", t => {
+test("createStyled wrapper", t => {
   t.plan(1);
 
   const customStyled = createStyled({

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -7,12 +7,15 @@ import * as React from "react";
 
 import {
   styled,
+  createStyled,
   withWrapper,
   withStyle,
   withStyleDeep,
   withTransform,
   Provider,
 } from "../index.js";
+
+import {getInitialStyle, driver} from "styletron-standard";
 
 Enzyme.configure({adapter: new Adapter()});
 
@@ -113,7 +116,11 @@ test("withStyle (dynamic)", t => {
     <Provider
       value={{
         renderStyle: x => {
-          t.deepEqual(x, {color: "red", background: "green", fontSize: "14px"});
+          t.deepEqual(x, {
+            color: "red",
+            background: "green",
+            fontSize: "14px",
+          });
           return "";
         },
         renderKeyframes: () => "",
@@ -505,6 +512,32 @@ test("keyframes injection", t => {
       }}
     >
       <Widget />
+    </Provider>,
+  );
+  t.end();
+});
+
+test.only("createStyled wrapper", t => {
+  t.plan(1);
+
+  const customStyled = createStyled({
+    driver,
+    getInitialStyle,
+    wrapper: _Component => props => {
+      t.equal(props.foo, "foo");
+      return <div>hello world</div>;
+    },
+  });
+  const Widget = customStyled("div", {color: "red"});
+  Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: () => "",
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+    >
+      <Widget foo="foo" />
     </Provider>,
   );
   t.end();

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -131,7 +131,7 @@ export function createStyled({
       base: base,
       driver,
       getInitialStyle,
-      wrapper: Component => Component,
+      wrapper,
     };
 
     if (__BROWSER__ && __DEV__) {


### PR DESCRIPTION
https://github.com/styletron/styletron/pull/279 mistakenly changed `createStyled` to always use the default wrapper instead of using the passed `wrapper` property of the parameter.

This PR fixes this and adds a regression test.
