### PR TITLE
Add configurable package whitelist to display name babel plugin

### DIFF
--- a/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/config.json
+++ b/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/config.json
@@ -1,0 +1,1 @@
+{"ignorePackageName": true}

--- a/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/config.json
+++ b/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/config.json
@@ -1,1 +1,1 @@
-{"ignorePackageName": true}
+{"importSources": "any"}

--- a/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/input
+++ b/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/input
@@ -1,0 +1,3 @@
+import { styled } from "../style-utils.js";
+const Foo = styled("div", { color: "red" });
+const Bar = styled("div", { color: "red" });

--- a/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/output
+++ b/packages/babel-plugin-transform-styletron-display-name/src/__tests__/fixtures/package-unrelated-ignore/output
@@ -1,0 +1,3 @@
+import { styled } from "../style-utils.js";
+const Foo = styled("div", { color: "red" });Foo.displayName = "Foo";
+const Bar = styled("div", { color: "red" });Bar.displayName = "Bar";

--- a/packages/babel-plugin-transform-styletron-display-name/src/__tests__/test.node.js
+++ b/packages/babel-plugin-transform-styletron-display-name/src/__tests__/test.node.js
@@ -14,11 +14,24 @@ function readFixtureFile(fixture, name) {
   return fs.readFileSync(path.resolve(FIXTURES_PATH, fixture, name), "utf8");
 }
 
+function readFixtureConfig(fixture) {
+  try {
+    const raw = fs.readFileSync(
+      path.resolve(FIXTURES_PATH, fixture, "config.json"),
+      "utf8",
+    );
+    return JSON.parse(raw);
+  } catch (error) {
+    return {};
+  }
+}
+
 function compare(fixture) {
   const input = readFixtureFile(fixture, "input");
   const output = readFixtureFile(fixture, "output");
+  const config = readFixtureConfig(fixture);
   const {code} = babel.transformSync(input, {
-    plugins: [plugin],
+    plugins: [[plugin, config]],
     retainLines: true,
   });
   test(fixture, t => {

--- a/packages/babel-plugin-transform-styletron-display-name/src/index.js
+++ b/packages/babel-plugin-transform-styletron-display-name/src/index.js
@@ -1,11 +1,11 @@
-/* global require module */
+/* global module */
 
-module.exports = function(babel, state) {
+module.exports = function(babel, s) {
   return {
     name: "transform-styletron-display-name",
     visitor: createNamedModuleVisitor(
       babel.types,
-      state,
+      s,
       ["styled", "withStyle", "withStyleDeep"],
       ["styletron-react", "fusion-plugin-styletron-react", "baseui"],
       (t, state, refPaths) => {

--- a/packages/babel-plugin-transform-styletron-display-name/src/index.js
+++ b/packages/babel-plugin-transform-styletron-display-name/src/index.js
@@ -1,12 +1,11 @@
 /* global require module */
 
-const types = require("@babel/core").types;
-
-module.exports = function() {
+module.exports = function(babel, state) {
   return {
     name: "transform-styletron-display-name",
     visitor: createNamedModuleVisitor(
-      types,
+      babel.types,
+      state,
       ["styled", "withStyle", "withStyleDeep"],
       ["styletron-react", "fusion-plugin-styletron-react", "baseui"],
       (t, state, refPaths) => {
@@ -32,14 +31,22 @@ module.exports = function() {
   };
 };
 
-function createNamedModuleVisitor(t, moduleNames, packageNames, refsHandler) {
+function createNamedModuleVisitor(
+  t,
+  s,
+  moduleNames,
+  packageNames,
+  refsHandler,
+) {
   return {
     // Handle ES imports
     // import {moduleName} from 'packageName';
     ImportDeclaration(path, state) {
       const sourceName = path.get("source").node.value;
 
-      if (packageNames.indexOf(sourceName) === -1) {
+      // {ignorePackageName: true} enables plugin to transform any imported module
+      // with a matching moduleName. Allows for relative path imports.
+      if (packageNames.indexOf(sourceName) === -1 && !s.ignorePackageName) {
         return;
       }
 


### PR DESCRIPTION
loaded the transform into the baseui repo, but realized that I overlooked my relative imports when implementing the import package strategy. i went ahead and added this pr to allow for ignoring the package name. 

see this [example file](https://github.com/uber-web/baseui/blob/master/src/card/styled-components.js#L10) for reference. what we think about this strategy?