### PR TITLE
Sort media queries, mobile first 

### DIFF
--- a/packages/styletron-engine-atomic/src/__tests__/test.node.js
+++ b/packages/styletron-engine-atomic/src/__tests__/test.node.js
@@ -4,6 +4,8 @@ import test from "tape";
 
 import {validateNoMixedHand} from "../validate-no-mixed-hand.js";
 
+import sortMq from "../sort-css-media-queries.js";
+
 test("validateNoMixedHand", t => {
   t.deepEqual(
     validateNoMixedHand({
@@ -26,5 +28,121 @@ test("validateNoMixedHand", t => {
       },
     ],
   );
+  t.end();
+});
+
+test("sortMq simple", t => {
+  const receivedOrder = [
+    "screen and (max-width: 640px)",
+    "screen and (min-width: 980px)",
+    "screen and (max-width: 980px)",
+    "screen and (max-width: 768px)",
+    "screen and (min-width: 640px)",
+    "screen and (min-width: 1280px)",
+    "screen and (min-width: 768px)",
+    "screen and (max-width: 1280px)",
+  ];
+
+  const expectedOrder = [
+    "screen and (min-width: 640px)",
+    "screen and (min-width: 768px)",
+    "screen and (min-width: 980px)",
+    "screen and (min-width: 1280px)",
+    "screen and (max-width: 1280px)",
+    "screen and (max-width: 980px)",
+    "screen and (max-width: 768px)",
+    "screen and (max-width: 640px)",
+  ];
+  t.deepEqual(receivedOrder.sort(sortMq), expectedOrder);
+  t.end();
+});
+
+test("sortMq simple 2", t => {
+  const receivedOrder = [
+    "screen and (max-width: 640px)",
+    "screen and (max-width: 640px)",
+    "screen and (min-width: 1280px)",
+    "screen and (max-width: 640px)",
+  ];
+
+  const expectedOrder = [
+    "screen and (min-width: 1280px)",
+    "screen and (max-width: 640px)",
+    "screen and (max-width: 640px)",
+    "screen and (max-width: 640px)",
+  ];
+  t.deepEqual(receivedOrder.sort(sortMq), expectedOrder);
+  t.end();
+});
+
+test("sortMq no media type", t => {
+  const receivedOrder = [
+    "(min-width: 980px)",
+    "(min-width: 640px)",
+    "(min-width: 768px)",
+  ];
+
+  const expectedOrder = [
+    "(min-width: 640px)",
+    "(min-width: 768px)",
+    "(min-width: 980px)",
+  ];
+  t.deepEqual(receivedOrder.sort(sortMq), expectedOrder);
+  t.end();
+});
+
+test("sortMq without dimension", t => {
+  const receivedOrder = [
+    "tv",
+    "print and (orientation: landscape)",
+    "print and (orientation: portrait)",
+    "print and (orientation: portrait)",
+    "screen and (orientation: landscape)",
+    "print",
+    "screen and (orientation: portrait)",
+    "print and (orientation: landscape)",
+    "print and (orientation: portrait)",
+  ];
+  const expectedOrder = [
+    "screen and (orientation: landscape)",
+    "screen and (orientation: portrait)",
+    "tv",
+    "print",
+    "print and (orientation: landscape)",
+    "print and (orientation: landscape)",
+    "print and (orientation: portrait)",
+    "print and (orientation: portrait)",
+    "print and (orientation: portrait)",
+  ];
+  t.deepEqual(receivedOrder.sort(sortMq), expectedOrder);
+  t.end();
+});
+
+test("mixed", t => {
+  const receivedOrder = [
+    "tv",
+    "print and (orientation: landscape)",
+    "screen and (min-width: 1280px)",
+    "screen and (max-width: 640px)",
+    "screen and (orientation: landscape)",
+    "print",
+    "screen and (orientation: portrait)",
+    "screen and (min-width: 768px)",
+    "screen and (max-width: 1280px)",
+    "print and (orientation: portrait)",
+  ];
+  const expectedOrder = [
+    "screen and (min-width: 768px)",
+    "screen and (min-width: 1280px)",
+    "screen and (max-width: 1280px)",
+    "screen and (max-width: 640px)",
+    "screen and (orientation: landscape)",
+    "screen and (orientation: portrait)",
+    "tv",
+    "print",
+    "print and (orientation: landscape)",
+    "print and (orientation: portrait)",
+  ];
+  t.deepEqual(receivedOrder.sort(sortMq), expectedOrder);
   t.end();
 });

--- a/packages/styletron-engine-atomic/src/cache.js
+++ b/packages/styletron-engine-atomic/src/cache.js
@@ -28,9 +28,7 @@ export class MultiCache<T> {
       cache.key = key;
       this.sortedCacheKeys.push(key);
       this.sortedCacheKeys.sort(sortMq);
-      const insertAtIndex = this.sortedCacheKeys.findIndex(
-        media => media === key,
-      );
+      const insertAtIndex = this.sortedCacheKeys.indexOf(key);
       this.caches[key] = cache;
       this.onNewCache(key, cache, insertAtIndex);
     }

--- a/packages/styletron-engine-atomic/src/cache.js
+++ b/packages/styletron-engine-atomic/src/cache.js
@@ -1,12 +1,14 @@
 // @flow
 
 import SequentialIDGenerator from "./sequential-id-generator.js";
+import sortMq from "./sort-css-media-queries.js";
 
 export class MultiCache<T> {
   caches: {[string]: Cache<T>};
   idGenerator: SequentialIDGenerator;
-  onNewCache: (string, Cache<T>) => any;
+  onNewCache: (string, Cache<T>, number) => any;
   onNewValue: (cache: Cache<T>, id: string, value: T) => any;
+  sortedCacheKeys: string[];
 
   constructor(
     idGenerator: SequentialIDGenerator,
@@ -16,6 +18,7 @@ export class MultiCache<T> {
     this.idGenerator = idGenerator;
     this.onNewCache = onNewCache;
     this.onNewValue = onNewValue;
+    this.sortedCacheKeys = [];
     this.caches = {};
   }
 
@@ -23,10 +26,19 @@ export class MultiCache<T> {
     if (!this.caches[key]) {
       const cache = new Cache(this.idGenerator, this.onNewValue);
       cache.key = key;
+      this.sortedCacheKeys.push(key);
+      this.sortedCacheKeys.sort(sortMq);
+      const insertAtIndex = this.sortedCacheKeys.findIndex(
+        media => media === key,
+      );
       this.caches[key] = cache;
-      this.onNewCache(key, cache);
+      this.onNewCache(key, cache, insertAtIndex);
     }
     return this.caches[key];
+  }
+
+  getSortedCacheKeys() {
+    return this.sortedCacheKeys;
   }
 }
 

--- a/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
+++ b/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
@@ -50,14 +50,14 @@ test("rendering", t => {
   ]);
   t.equal(
     instance.renderStyle({
-      "@media (max-width: 800px)": {color: "purple"},
+      "@media (min-width: 800px)": {color: "purple"},
     }),
     "af",
     "new unique class returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {media: "", rules: [".ae { color: purple; }"]},
-    {media: "(max-width: 800px)", rules: [".af { color: purple; }"]},
+    {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
   ]);
   instance.renderStyle({
     userSelect: "none",
@@ -67,7 +67,7 @@ test("rendering", t => {
       media: "",
       rules: [".ae { color: purple; }", ".ag { user-select: none; }"],
     },
-    {media: "(max-width: 800px)", rules: [".af { color: purple; }"]},
+    {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
   ]);
   instance.renderStyle({
     display: "flex",
@@ -81,8 +81,29 @@ test("rendering", t => {
         ".ah { display: flex; }",
       ],
     },
-    {media: "(max-width: 800px)", rules: [".af { color: purple; }"]},
+    {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
   ]);
+  instance.renderStyle({
+    "@media (min-width: 600px)": {
+      color: "red",
+    },
+  });
+  t.deepEqual(
+    sheetsToRules(document.styleSheets),
+    [
+      {
+        media: "",
+        rules: [
+          ".ae { color: purple; }",
+          ".ag { user-select: none; }",
+          ".ah { display: flex; }",
+        ],
+      },
+      {media: "(min-width: 600px)", rules: [".ai { color: red; }"]},
+      {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+    ],
+    "media queries are mobile first sorted",
+  );
   instance.container.remove();
   t.end();
 });
@@ -156,12 +177,17 @@ function injectFixtureStyles(styletron) {
   styletron.renderStyle({color: "red"});
   styletron.renderStyle({color: "green"});
   styletron.renderStyle({
-    "@media (max-width: 800px)": {
+    "@media (min-width: 800px)": {
       color: "green",
     },
   });
   styletron.renderStyle({
-    "@media (max-width: 800px)": {
+    "@media (min-width: 600px)": {
+      color: "red",
+    },
+  });
+  styletron.renderStyle({
+    "@media (min-width: 800px)": {
       ":hover": {
         color: "green",
       },

--- a/packages/styletron-engine-atomic/src/client/client.js
+++ b/packages/styletron-engine-atomic/src/client/client.js
@@ -98,10 +98,17 @@ class StyletronClient implements StandardEngine {
     // Setup style cache
     this.styleCache = new MultiCache(
       styleIdGenerator,
-      media => {
+      (media, _cache, insertAtIndex) => {
         const styleElement = document.createElement("style");
         styleElement.media = media;
-        this.container.appendChild(styleElement);
+        if (insertAtIndex >= this.container.children.length) {
+          this.container.appendChild(styleElement);
+        } else {
+          this.container.insertBefore(
+            styleElement,
+            this.container.children[insertAtIndex],
+          );
+        }
         this.styleElements[media] = styleElement;
       },
       onNewStyle,

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -9,17 +9,17 @@ test("StyletronServer toCss", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ag{color:red}}@media (min-width: 800px){.ah{color:green}.ai:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ag{color:red}}@media (min-width: 800px){.ah{color:green}.ai:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ag{color:red}}@media (min-width: 800px){.ah{color:green}.ai:hover{color:green}}@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
   );
   t.end();
 });
@@ -38,9 +38,9 @@ test("StyletronServer getStylesheets", t => {
         ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ag{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ah{color:green}.ai:hover{color:green}",
+      css: ".ag{color:green}.ai:hover{color:green}",
       attrs: {media: "(min-width: 800px)"},
     },
   ]);
@@ -51,9 +51,9 @@ test("StyletronServer getStylesheets", t => {
         ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ag{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ah{color:green}.ai:hover{color:green}",
+      css: ".ag{color:green}.ai:hover{color:green}",
       attrs: {media: "(min-width: 800px)"},
     },
     {
@@ -72,9 +72,9 @@ test("StyletronServer getStylesheets", t => {
         ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ag{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ah{color:green}.ai:hover{color:green}",
+      css: ".ag{color:green}.ai:hover{color:green}",
       attrs: {media: "(min-width: 800px)"},
     },
     {
@@ -96,17 +96,17 @@ test("StyletronServer getStylesheetsHtml ", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ag{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ah{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ag{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ah{color:green}.ai:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
   );
   injectFixtureFontFace(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ag{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ah{color:green}.ai:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
   );
   t.end();
 });
@@ -135,13 +135,15 @@ function injectFixtureStyles(styletron) {
   styletron.renderStyle({color: "red"});
   styletron.renderStyle({color: "green"});
   styletron.renderStyle({
-    "@media (min-width: 600px)": {
-      color: "red",
-    },
-  });
-  styletron.renderStyle({
     "@media (min-width: 800px)": {
       color: "green",
+    },
+  });
+  // should be added before "min-width: 800px" query
+  // test that Styletron properly sort media queries
+  styletron.renderStyle({
+    "@media (min-width: 600px)": {
+      color: "red",
     },
   });
   styletron.renderStyle({

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -9,17 +9,17 @@ test("StyletronServer toCss", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.ag{color:green}.ah:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ag{color:red}}@media (min-width: 800px){.ah{color:green}.ai:hover{color:green}}",
   );
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.ag{color:green}.ah:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ag{color:red}}@media (min-width: 800px){.ah{color:green}.ai:hover{color:green}}",
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (max-width: 800px){.ag{color:green}.ah:hover{color:green}}@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ag{color:red}}@media (min-width: 800px){.ah{color:green}.ai:hover{color:green}}@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
   );
   t.end();
 });
@@ -35,24 +35,26 @@ test("StyletronServer getStylesheets", t => {
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
+    {css: ".ag{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ag{color:green}.ah:hover{color:green}",
-      attrs: {media: "(max-width: 800px)"},
+      css: ".ah{color:green}.ai:hover{color:green}",
+      attrs: {media: "(min-width: 800px)"},
     },
   ]);
   injectFixtureKeyframes(styletron);
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
+    {css: ".ag{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ag{color:green}.ah:hover{color:green}",
-      attrs: {media: "(max-width: 800px)"},
+      css: ".ah{color:green}.ai:hover{color:green}",
+      attrs: {media: "(min-width: 800px)"},
     },
     {
       css: "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
@@ -67,12 +69,13 @@ test("StyletronServer getStylesheets", t => {
     },
     {
       css:
-        ".ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
+    {css: ".ag{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ag{color:green}.ah:hover{color:green}",
-      attrs: {media: "(max-width: 800px)"},
+      css: ".ah{color:green}.ai:hover{color:green}",
+      attrs: {media: "(min-width: 800px)"},
     },
     {
       css: "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
@@ -93,17 +96,17 @@ test("StyletronServer getStylesheetsHtml ", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.ag{color:green}.ah:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ag{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ah{color:green}.ai:hover{color:green}</style>',
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.ag{color:green}.ah:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ag{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ah{color:green}.ai:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
   );
   injectFixtureFontFace(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.ai:hover{display:none}.aj{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ak{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(max-width: 800px)">.ag{color:green}.ah:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ag{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ah{color:green}.ai:hover{color:green}</style><style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style>',
   );
   t.end();
 });
@@ -132,12 +135,17 @@ function injectFixtureStyles(styletron) {
   styletron.renderStyle({color: "red"});
   styletron.renderStyle({color: "green"});
   styletron.renderStyle({
-    "@media (max-width: 800px)": {
+    "@media (min-width: 600px)": {
+      color: "red",
+    },
+  });
+  styletron.renderStyle({
+    "@media (min-width: 800px)": {
       color: "green",
     },
   });
   styletron.renderStyle({
-    "@media (max-width: 800px)": {
+    "@media (min-width: 800px)": {
       ":hover": {
         color: "green",
       },

--- a/packages/styletron-engine-atomic/src/sort-css-media-queries.js
+++ b/packages/styletron-engine-atomic/src/sort-css-media-queries.js
@@ -1,0 +1,250 @@
+"use strict";
+
+/**
+ * The custom `sort` method for
+ * for the [`css-mqpacker`](https://www.npmjs.com/package/css-mqpacker) or
+ * [`pleeease`](https://www.npmjs.com/package/pleeease) which using `css-mqpacker`
+ * or, perhaps, something else ))
+ *
+ * @module sort-css-media-queries
+ * @author Oleg Dutchenko <dutchenko.o.wezom@gmail.com>
+ * @version 1.4.0
+ */
+
+// ----------------------------------------
+// Private
+// ----------------------------------------
+
+const minMaxWidth = /(!?\(\s*min(-device-)?-width).+\(\s*max(-device)?-width/i;
+const minWidth = /\(\s*min(-device)?-width/i;
+const maxMinWidth = /(!?\(\s*max(-device)?-width).+\(\s*min(-device)?-width/i;
+const maxWidth = /\(\s*max(-device)?-width/i;
+
+const isMinWidth = _testQuery(minMaxWidth, maxMinWidth, minWidth);
+const isMaxWidth = _testQuery(maxMinWidth, minMaxWidth, maxWidth);
+
+const minMaxHeight = /(!?\(\s*min(-device)?-height).+\(\s*max(-device)?-height/i;
+const minHeight = /\(\s*min(-device)?-height/i;
+const maxMinHeight = /(!?\(\s*max(-device)?-height).+\(\s*min(-device)?-height/i;
+const maxHeight = /\(\s*max(-device)?-height/i;
+
+const isMinHeight = _testQuery(minMaxHeight, maxMinHeight, minHeight);
+const isMaxHeight = _testQuery(maxMinHeight, minMaxHeight, maxHeight);
+
+const isPrint = /print/i;
+const isPrintOnly = /^print$/i;
+
+const maxValue = Number.MAX_VALUE;
+
+/**
+ * Obtain the length of the media request in pixels.
+ * Copy from original source `function inspectLength (length)`
+ * {@link https://github.com/hail2u/node-css-mqpacker/blob/master/index.js#L58}
+ * @private
+ * @param {string} length
+ * @return {number}
+ */
+function _getQueryLength(length) {
+  length = /(-?\d*\.?\d+)(ch|em|ex|px|rem)/.exec(length);
+
+  if (length === null) {
+    return maxValue;
+  }
+
+  let number = length[1];
+  const unit = length[2];
+
+  switch (unit) {
+    case "ch":
+      number = parseFloat(number) * 8.8984375;
+      break;
+
+    case "em":
+    case "rem":
+      number = parseFloat(number) * 16;
+      break;
+
+    case "ex":
+      number = parseFloat(number) * 8.296875;
+      break;
+
+    case "px":
+      number = parseFloat(number);
+      break;
+  }
+
+  return +number;
+}
+
+/**
+ * Wrapper for creating test functions
+ * @private
+ * @param {RegExp} doubleTestTrue
+ * @param {RegExp} doubleTestFalse
+ * @param {RegExp} singleTest
+ * @return {Function}
+ */
+function _testQuery(doubleTestTrue, doubleTestFalse, singleTest) {
+  /**
+   * @param {string} query
+   * @return {boolean}
+   */
+  return function(query) {
+    if (doubleTestTrue.test(query)) {
+      return true;
+    } else if (doubleTestFalse.test(query)) {
+      return false;
+    }
+    return singleTest.test(query);
+  };
+}
+
+/**
+ * @private
+ * @param {string} a
+ * @param {string} b
+ * @return {number|null}
+ */
+function _testIsPrint(a, b) {
+  const isPrintA = isPrint.test(a);
+  const isPrintOnlyA = isPrintOnly.test(a);
+
+  const isPrintB = isPrint.test(b);
+  const isPrintOnlyB = isPrintOnly.test(b);
+
+  if (isPrintA && isPrintB) {
+    if (!isPrintOnlyA && isPrintOnlyB) {
+      return 1;
+    }
+    if (isPrintOnlyA && !isPrintOnlyB) {
+      return -1;
+    }
+    return a.localeCompare(b);
+  }
+  if (isPrintA) {
+    return 1;
+  }
+  if (isPrintB) {
+    return -1;
+  }
+
+  return null;
+}
+
+// ----------------------------------------
+// Public
+// ----------------------------------------
+
+/**
+ * Sorting an array with media queries
+ * according to the mobile-first methodology.
+ * @param {string} a
+ * @param {string} b
+ * @return {number} 1 / 0 / -1
+ */
+export default function sortCSSmq(a, b) {
+  if (a === "") {
+    return -1;
+  }
+  if (b === "") {
+    return 1;
+  }
+  const testIsPrint = _testIsPrint(a, b);
+  if (testIsPrint !== null) {
+    return testIsPrint;
+  }
+
+  const minA = isMinWidth(a) || isMinHeight(a);
+  const maxA = isMaxWidth(a) || isMaxHeight(a);
+
+  const minB = isMinWidth(b) || isMinHeight(b);
+  const maxB = isMaxWidth(b) || isMaxHeight(b);
+
+  if (minA && maxB) {
+    return -1;
+  }
+  if (maxA && minB) {
+    return 1;
+  }
+
+  const lengthA = _getQueryLength(a);
+  const lengthB = _getQueryLength(b);
+
+  if (lengthA === maxValue && lengthB === maxValue) {
+    return a.localeCompare(b);
+  } else if (lengthA === maxValue) {
+    return 1;
+  } else if (lengthB === maxValue) {
+    return -1;
+  }
+
+  if (lengthA > lengthB) {
+    if (maxA) {
+      return -1;
+    }
+    return 1;
+  }
+
+  if (lengthA < lengthB) {
+    if (maxA) {
+      return 1;
+    }
+    return -1;
+  }
+
+  return a.localeCompare(b);
+}
+
+/**
+ * Sorting an array with media queries
+ * according to the desktop-first methodology.
+ * @param {string} a
+ * @param {string} b
+ * @return {number} 1 / 0 / -1
+ */
+sortCSSmq.desktopFirst = function(a, b) {
+  const testIsPrint = _testIsPrint(a, b);
+  if (testIsPrint !== null) {
+    return testIsPrint;
+  }
+
+  const minA = isMinWidth(a) || isMinHeight(a);
+  const maxA = isMaxWidth(a) || isMaxHeight(a);
+
+  const minB = isMinWidth(b) || isMinHeight(b);
+  const maxB = isMaxWidth(b) || isMaxHeight(b);
+
+  if (minA && maxB) {
+    return 1;
+  }
+  if (maxA && minB) {
+    return -1;
+  }
+
+  const lengthA = _getQueryLength(a);
+  const lengthB = _getQueryLength(b);
+
+  if (lengthA === maxValue && lengthB === maxValue) {
+    return a.localeCompare(b);
+  } else if (lengthA === maxValue) {
+    return 1;
+  } else if (lengthB === maxValue) {
+    return -1;
+  }
+
+  if (lengthA > lengthB) {
+    if (maxA) {
+      return -1;
+    }
+    return 1;
+  }
+
+  if (lengthA < lengthB) {
+    if (maxA) {
+      return 1;
+    }
+    return -1;
+  }
+
+  return -a.localeCompare(b);
+};

--- a/packages/styletron-engine-atomic/src/sort-css-media-queries.js
+++ b/packages/styletron-engine-atomic/src/sort-css-media-queries.js
@@ -1,19 +1,6 @@
-"use strict";
+// adapted from https://github.com/dutchenkoOleg/sort-css-media-queries
 
-/**
- * The custom `sort` method for
- * for the [`css-mqpacker`](https://www.npmjs.com/package/css-mqpacker) or
- * [`pleeease`](https://www.npmjs.com/package/pleeease) which using `css-mqpacker`
- * or, perhaps, something else ))
- *
- * @module sort-css-media-queries
- * @author Oleg Dutchenko <dutchenko.o.wezom@gmail.com>
- * @version 1.4.0
- */
-
-// ----------------------------------------
-// Private
-// ----------------------------------------
+// @flow
 
 const minMaxWidth = /(!?\(\s*min(-device-)?-width).+\(\s*max(-device)?-width/i;
 const minWidth = /\(\s*min(-device)?-width/i;
@@ -33,63 +20,39 @@ const isMaxHeight = _testQuery(maxMinHeight, minMaxHeight, maxHeight);
 
 const isPrint = /print/i;
 const isPrintOnly = /^print$/i;
-
 const maxValue = Number.MAX_VALUE;
 
-/**
- * Obtain the length of the media request in pixels.
- * Copy from original source `function inspectLength (length)`
- * {@link https://github.com/hail2u/node-css-mqpacker/blob/master/index.js#L58}
- * @private
- * @param {string} length
- * @return {number}
- */
-function _getQueryLength(length) {
-  length = /(-?\d*\.?\d+)(ch|em|ex|px|rem)/.exec(length);
-
-  if (length === null) {
+function _getQueryLength(length: string) {
+  const matches = /(-?\d*\.?\d+)(ch|em|ex|px|rem)/.exec(length);
+  if (matches === null) {
     return maxValue;
   }
-
-  let number = length[1];
-  const unit = length[2];
-
+  let number = matches[1];
+  const unit = matches[2];
   switch (unit) {
     case "ch":
       number = parseFloat(number) * 8.8984375;
       break;
-
     case "em":
     case "rem":
       number = parseFloat(number) * 16;
       break;
-
     case "ex":
       number = parseFloat(number) * 8.296875;
       break;
-
     case "px":
       number = parseFloat(number);
       break;
   }
-
   return +number;
 }
 
-/**
- * Wrapper for creating test functions
- * @private
- * @param {RegExp} doubleTestTrue
- * @param {RegExp} doubleTestFalse
- * @param {RegExp} singleTest
- * @return {Function}
- */
-function _testQuery(doubleTestTrue, doubleTestFalse, singleTest) {
-  /**
-   * @param {string} query
-   * @return {boolean}
-   */
-  return function(query) {
+function _testQuery(
+  doubleTestTrue: RegExp,
+  doubleTestFalse: RegExp,
+  singleTest: RegExp,
+) {
+  return function(query: string) {
     if (doubleTestTrue.test(query)) {
       return true;
     } else if (doubleTestFalse.test(query)) {
@@ -99,16 +62,9 @@ function _testQuery(doubleTestTrue, doubleTestFalse, singleTest) {
   };
 }
 
-/**
- * @private
- * @param {string} a
- * @param {string} b
- * @return {number|null}
- */
-function _testIsPrint(a, b) {
+function _testIsPrint(a: string, b: string) {
   const isPrintA = isPrint.test(a);
   const isPrintOnlyA = isPrintOnly.test(a);
-
   const isPrintB = isPrint.test(b);
   const isPrintOnlyB = isPrintOnly.test(b);
 
@@ -127,22 +83,10 @@ function _testIsPrint(a, b) {
   if (isPrintB) {
     return -1;
   }
-
   return null;
 }
 
-// ----------------------------------------
-// Public
-// ----------------------------------------
-
-/**
- * Sorting an array with media queries
- * according to the mobile-first methodology.
- * @param {string} a
- * @param {string} b
- * @return {number} 1 / 0 / -1
- */
-export default function sortCSSmq(a, b) {
+export default function sortCSSmq(a: string, b: string) {
   if (a === "") {
     return -1;
   }
@@ -156,7 +100,6 @@ export default function sortCSSmq(a, b) {
 
   const minA = isMinWidth(a) || isMinHeight(a);
   const maxA = isMaxWidth(a) || isMaxHeight(a);
-
   const minB = isMinWidth(b) || isMinHeight(b);
   const maxB = isMaxWidth(b) || isMaxHeight(b);
 
@@ -194,57 +137,3 @@ export default function sortCSSmq(a, b) {
 
   return a.localeCompare(b);
 }
-
-/**
- * Sorting an array with media queries
- * according to the desktop-first methodology.
- * @param {string} a
- * @param {string} b
- * @return {number} 1 / 0 / -1
- */
-sortCSSmq.desktopFirst = function(a, b) {
-  const testIsPrint = _testIsPrint(a, b);
-  if (testIsPrint !== null) {
-    return testIsPrint;
-  }
-
-  const minA = isMinWidth(a) || isMinHeight(a);
-  const maxA = isMaxWidth(a) || isMaxHeight(a);
-
-  const minB = isMinWidth(b) || isMinHeight(b);
-  const maxB = isMaxWidth(b) || isMaxHeight(b);
-
-  if (minA && maxB) {
-    return 1;
-  }
-  if (maxA && minB) {
-    return -1;
-  }
-
-  const lengthA = _getQueryLength(a);
-  const lengthB = _getQueryLength(b);
-
-  if (lengthA === maxValue && lengthB === maxValue) {
-    return a.localeCompare(b);
-  } else if (lengthA === maxValue) {
-    return 1;
-  } else if (lengthB === maxValue) {
-    return -1;
-  }
-
-  if (lengthA > lengthB) {
-    if (maxA) {
-      return -1;
-    }
-    return 1;
-  }
-
-  if (lengthA < lengthB) {
-    if (maxA) {
-      return 1;
-    }
-    return -1;
-  }
-
-  return -a.localeCompare(b);
-};


### PR DESCRIPTION
## Problem

Styletron currently doesn't do anything about the order of media queries and they can be injected in a random order as components get mounted. However, the order of media queries matters since:

```
(min-width: 480px)
(min-width: 600px)
```

and

```
(min-width: 600px)
(min-width: 480px)
```

would yield different results when the viewport's width is over 600px - the last matched definition wins. In mobile-first approach, it's preferred to enforce the ascendant order.

## Solution

`styletron-engine-atomic` can parse media queries and keep them sorted. There is a new variable `MutliCache.sortedCacheKeys` added for this purpose. When a new `media` key appears (cache miss), it's added to the end of `sortedCacheKeys` and the the `sortedCacheKeys` array is sorted using this [implementation](https://github.com/dutchenkoOleg/sort-css-media-queries) (without the `desktopFirst` part).

`StyletronServer` then uses `sortedCacheKeys` in `stringify` and `sheetify` methods to enforce this order correctly. `StyletronClient` doesn't need the whole `sortedCacheKeys` array but only the position where the new `media` stylesheet should be inserted through the `insertAtIndex` variable.

## Notes

### Mobile first vs desktop first

You can't have it both so Styletron will do mobile-first by default.

### Perf
I didn't want to touch / rewrite the css sort so I didn't do one slight optimization: Since we are building a sorted `sortedCacheKeys` array from scratch we could use more efficient algorithm `O(n)` (or even `O(logn)`) where `n` is number of media queries. This implementation sorts `sortedCacheKeys` with every new key so it's `O(n*logn)`. However, typical application has only a few different breakpoints and this sort happens only when the cache is not hit, so it has almost zero impact. However, if it's important to you, I can spend more time and update it (although it would come with more code / bundle size).

// cc @gergelyke @chasestarr @nadiia
