### PR TITLE
Use ElementConfig instead of ElementProps

### DIFF
--- a/packages/flow-type-tests/exact-props.js
+++ b/packages/flow-type-tests/exact-props.js
@@ -10,3 +10,6 @@ const MyComponent: React.ComponentType<{|foo: 42|}> = _props => {
 const MyStyledComponent = styled(MyComponent, {color: "red"});
 
 <MyStyledComponent foo={42} />;
+
+// $FlowFixMe
+<MyStyledComponent foo={42} invalidProp={42} />; // Should fail, not in props

--- a/packages/flow-type-tests/exact-props.js
+++ b/packages/flow-type-tests/exact-props.js
@@ -1,0 +1,12 @@
+// @flow
+
+import * as React from "react";
+import {styled} from "styletron-react";
+
+const MyComponent: React.ComponentType<{|foo: 42|}> = _props => {
+  return null;
+};
+
+const MyStyledComponent = styled(MyComponent, {color: "red"});
+
+<MyStyledComponent foo={42} />;

--- a/packages/styletron-react/src/types.js
+++ b/packages/styletron-react/src/types.js
@@ -3,7 +3,7 @@
 import type {
   ComponentType,
   StatelessFunctionalComponent,
-  ElementProps,
+  ElementConfig,
 } from "react";
 import type {StyleObject} from "styletron-standard";
 
@@ -55,11 +55,11 @@ export type StyledFn = {
   <Base: ComponentType<any>>(
     Base,
     StyleObject,
-  ): StyletronComponent<$Diff<ElementProps<Base>, {className: any}>>,
+  ): StyletronComponent<$Diff<ElementConfig<Base>, {className: any}>>,
   <Base: ComponentType<any>, Props>(
     Base,
     (Props) => StyleObject,
-  ): StyletronComponent<$Diff<ElementProps<Base>, {className: any}> & Props>,
+  ): StyletronComponent<$Diff<ElementConfig<Base>, {className: any}> & Props>,
 };
 
 export type WithStyleFn = {


### PR DESCRIPTION
When ElementProps is used with `ComponentType` the props are not extracted properly. According to the [doc](https://flow.org/en/docs/react/types/#toc-react-elementprops) ElementConfig might be a better choice. 



[Try Flow Example](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAtgBzgJwBdkwBDAZzACUBTUgY2KnzizAHJ87H2BudenAB25YgFkAngGFWeITSGEAXNW6EAdDNzCFhACoScNADwBvAD5Q4cFQBYATOYC+APjABeMAAocLHOQBKDzdTVABILkIAV3whMCEomBhUJwFhUTBJAGVCUkIaGBpyci05XRVaBg0cvIKi8gAxKKFGDGFSGFKdRTNLaztHVw9vXzh-IPcQ8MiYuISklPQaAA88IjBCQxowHIlCgBMAeXwMAHMMIQ6GuM9QsDBjACEKGgq1TVlu-S3jUiEJFwuLyoe73Z7kGgAGhBYACbyqH208kUBiMxgAJAARDBQKDGSqMdQAUUKWF0AAU-OQni8XJCwKZ6DAKOQAHKkMkqP4SVx0lL8UFgVArNbETZGHabA4yIRQM7XYZ3B7g16qBFdZHfNHcwHAwUq6H3OFqwka3SokxYnF4gkaEk0MmKGVy040iF0hlMlnszlkf686FOXiCkMwkNCwQiYiiPY0Y5nC4dFS7A7x86XGAKzxeLwTEJOLn-ILhwWoSMZGOFZ1nZNSmj7aunLPeXPBBkFv0SYsl+5hnsR9LEFP1yRmxRpxMwYaVuMndMdLyjz6agJlweS2P7JdI3SN6d1xuL6TL3Sr3vlod1rcSGr5QrFMeECcZ-ex58L7K5O-1R+ri8bg5P1qe8ShPJ1hBdV8qwgs4j1vOoHzAwgz37AcozAIkAEZhmMbcykUMArDgdxTAcJx7mANxSz7HtUGAYAwAAdW2BA4ESfYwBFGhGA2AALDBKEIOAwFY-AAGt1Dohj0QaeAEAaDBljEbYAFowAaawwAEsAsAE8gLlOLS4lGfxvAwQh2EoIQ4GQtd0KJewcOHa9H3fKciJIsiwEo0MpIA+sFVEsTKAQXiFAw0ldxgwztKiCEONQxK7IyIkAGYnKvPCvj3DzSPscifN7IV6LAGS5IUpTVPiYQiWWATcgI7TdOKAzvC4xh6yCP4OKIrTKGa-ShEMrxmna-J9m7RLz3XIlbAyzcss1NzCOsTz8uqoRavqv5CDWpxCtBdASrKxAKuUsA1Osza6tEHa+p0vTWq8MbOqmktkuIIkAFZ5sA48d3A2UzhW4i8vIq6ttuxQ9u8lwjoY5zAoIYKRLCuJH3u9h4JApoWkINoM0fdgpo+jCADZfpHG8vwQ0CAafOdJxBmGDqK0N-yJAB2Snr2xn8kJy1awdh6iSaAA)
