### PR TITLE
Add useStyletron hook and default no-op engine

### DIFF
--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -42,8 +42,8 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint-plugin-react": "^7.6.1",
-    "react": "16.7.0",
-    "react-dom": "16.7.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "unitest": "^2.1.1"
   },
   "license": "MIT"

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -30,12 +30,11 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "create-react-context": "^0.2.2",
     "prop-types": "^15.6.0",
     "styletron-standard": "^2.0.2"
   },
   "peerDependencies": {
-    "react": "0.14.x - 16.x"
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.0.0-beta.56",

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -13,6 +13,7 @@ import {
   withStyleDeep,
   withTransform,
   Provider,
+  useStyletron,
 } from "../index.js";
 
 import {getInitialStyle, driver} from "styletron-standard";
@@ -536,5 +537,85 @@ test("createStyled wrapper", t => {
       <Widget foo="foo" />
     </Provider>,
   );
+  t.end();
+});
+
+test("theme support", t => {
+  t.plan(1);
+
+  const Widget = styled<any>("div", ({$theme}) => ({
+    color: $theme.textColor,
+  }));
+
+  Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: x => {
+          t.deepEqual(x, {
+            color: "blue",
+          });
+          return "";
+        },
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+      theme={{
+        textColor: "blue",
+      }}
+    >
+      <Widget />
+    </Provider>,
+  );
+  t.end();
+});
+
+test("useStyletron css and theme", t => {
+  t.plan(2);
+
+  function Link() {
+    const {css, theme} = useStyletron();
+    const className = css({color: theme && theme.textColor});
+    t.equal(className, ".abc");
+    return <a className={className}>Foo</a>;
+  }
+
+  Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: x => {
+          t.deepEqual(x, {
+            color: "blue",
+          });
+          return ".abc";
+        },
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+      theme={{
+        textColor: "blue",
+      }}
+    >
+      <Link />
+    </Provider>,
+  );
+  t.end();
+});
+
+test("no-op engine", t => {
+  t.plan(1);
+  const consoleWarn = console.warn; // eslint-disable-line
+
+  (console: any).warn = message => {
+    t.equal(
+      message.split("\n")[1],
+      "Styletron has been switched to a no-op (test) mode.",
+    );
+  };
+  const Widget = styled("div", {
+    color: "red",
+  });
+  Enzyme.mount(<Widget />);
+
+  (console: any).warn = consoleWarn;
   t.end();
 });

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -540,41 +540,12 @@ test("createStyled wrapper", t => {
   t.end();
 });
 
-test("theme support", t => {
-  t.plan(1);
-
-  const Widget = styled<any>("div", ({$theme}) => ({
-    color: $theme.textColor,
-  }));
-
-  Enzyme.mount(
-    <Provider
-      value={{
-        renderStyle: x => {
-          t.deepEqual(x, {
-            color: "blue",
-          });
-          return "";
-        },
-        renderKeyframes: () => "",
-        renderFontFace: () => "",
-      }}
-      theme={{
-        textColor: "blue",
-      }}
-    >
-      <Widget />
-    </Provider>,
-  );
-  t.end();
-});
-
-test("useStyletron css and theme", t => {
+test("useStyletron css", t => {
   t.plan(2);
 
   function Link() {
-    const {css, theme} = useStyletron();
-    const className = css({color: theme && theme.textColor});
+    const [css] = useStyletron();
+    const className = css({color: "blue"});
     t.equal(className, ".abc");
     return <a className={className}>Foo</a>;
   }
@@ -590,9 +561,6 @@ test("useStyletron css and theme", t => {
         },
         renderKeyframes: () => "",
         renderFontFace: () => "",
-      }}
-      theme={{
-        textColor: "blue",
       }}
     >
       <Link />

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -6,7 +6,6 @@ declare var __DEV__: boolean;
 declare var __BROWSER__: boolean;
 
 import * as React from "react";
-import createReactContext, {type Context} from "create-react-context";
 import {
   driver,
   getInitialStyle,
@@ -30,9 +29,9 @@ import {addDebugMetadata, DebugEngine} from "./dev-tool.js";
 
 export {DebugEngine};
 
-const StyletronContext: Context<any> = createReactContext();
-const HydrationContext = createReactContext(false);
-const DebugEngineContext = createReactContext();
+const StyletronContext = React.createContext<*>();
+const HydrationContext = React.createContext(false);
+const DebugEngineContext = React.createContext();
 
 type DevProviderProps = {
   children: React.Node,

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -147,15 +147,23 @@ export function useStyletron() {
   return [
     function css(style: StyleObject) {
       const className = driver(style, styletronEngine);
-      if (__BROWSER__ && __DEV__ && debugEngine && !hydrating) {
-        const {stack, message} = new Error("stacktrace source");
-        const debugClassName = debugEngine.debug({
-          stackInfo: {stack, message},
-          stackIndex: 1,
-        });
-        return `${debugClassName} ${className}`;
+      if (!(__BROWSER__ && __DEV__)) {
+        return className;
       }
-      return className;
+      const {stack, message} = new Error("stacktrace source");
+      const debugClassName = React.useMemo(
+        () => {
+          if (debugEngine && !hydrating) {
+            return debugEngine.debug({
+              stackInfo: {stack, message},
+              stackIndex: 1,
+            });
+          }
+          return "";
+        },
+        [debugEngine, hydrating],
+      );
+      return debugClassName ? `${debugClassName} ${className}` : className;
     },
   ];
 }

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -164,10 +164,16 @@ export function useStyletron() {
     css: (style: StyleObject) => {
       checkNoopEngine(styletronEngine);
       const className = driver(style, styletronEngine);
-      if (__BROWSER__ && __DEV__ && debugEngine && !hydrating) {
-        const debugClassName = debugEngine.debug();
-        return `${debugClassName} ${className}`;
-      }
+      // TODO: Fix/enable debuging mode for this API
+      //
+      // if (__BROWSER__ && __DEV__ && debugEngine && !hydrating) {
+      //   const {stack, stacktrace, message} = new Error("stacktrace source");
+      //   const debugClassName = debugEngine.debug({
+      //     stackInfo: {stack, stacktrace, message},
+      //     stackIndex: 2,
+      //   });
+      //   return `${debugClassName} ${className}`;
+      // }
       return className;
     },
     theme,

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -30,12 +30,13 @@ import {addDebugMetadata, DebugEngine} from "./dev-tool.js";
 
 export {DebugEngine};
 
-const StyletronContext = React.createContext<StandardEngine>({
+const noopEngine = {
   renderStyle: () => "",
   renderKeyframes: () => "",
   renderFontFace: () => "",
-  noopEngine: true,
-});
+};
+
+const StyletronContext = React.createContext<StandardEngine>(noopEngine);
 const HydrationContext = React.createContext(false);
 const DebugEngineContext = React.createContext();
 const ThemeContext = React.createContext();
@@ -118,7 +119,7 @@ function checkNoopEngine(engine: StandardEngine) {
   // if no engine provided, we default to no-op, handy for tests
   // however, print a warning in other envs
   if (process.env.NODE_ENV !== "test") {
-    engine.noopEngine &&
+    engine === noopEngine &&
       // eslint-disable-next-line no-console
       console.warn(
         __DEV__

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -143,9 +143,9 @@ export function useStyletron() {
   const styletronEngine: StandardEngine = React.useContext(StyletronContext);
   const debugEngine = React.useContext(DebugEngineContext);
   const hydrating = React.useContext(HydrationContext);
+  checkNoopEngine(styletronEngine);
   return [
     function css(style: StyleObject) {
-      checkNoopEngine(styletronEngine);
       const className = driver(style, styletronEngine);
       if (__BROWSER__ && __DEV__ && debugEngine && !hydrating) {
         const {stack, message} = new Error("stacktrace source");

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -147,16 +147,14 @@ export function useStyletron() {
     function css(style: StyleObject) {
       checkNoopEngine(styletronEngine);
       const className = driver(style, styletronEngine);
-      // TODO: Fix/enable debuging mode for this API
-      //
-      // if (__BROWSER__ && __DEV__ && debugEngine && !hydrating) {
-      //   const {stack, stacktrace, message} = new Error("stacktrace source");
-      //   const debugClassName = debugEngine.debug({
-      //     stackInfo: {stack, stacktrace, message},
-      //     stackIndex: 2,
-      //   });
-      //   return `${debugClassName} ${className}`;
-      // }
+      if (__BROWSER__ && __DEV__ && debugEngine && !hydrating) {
+        const {stack, message} = new Error("stacktrace source");
+        const debugClassName = debugEngine.debug({
+          stackInfo: {stack, message},
+          stackIndex: 1,
+        });
+        return `${debugClassName} ${className}`;
+      }
       return className;
     },
   ];

--- a/packages/styletron-standard/src/index.js
+++ b/packages/styletron-standard/src/index.js
@@ -26,7 +26,6 @@ export interface StandardEngine {
   renderStyle(style: StyleObject): string;
   renderKeyframes(keyframes: KeyframesObject): string;
   renderFontFace(fontFace: FontFaceObject): string;
-  noopEngine?: boolean;
 }
 
 export function driver(style: StyleObject, styletron: StandardEngine): string {

--- a/packages/styletron-standard/src/index.js
+++ b/packages/styletron-standard/src/index.js
@@ -26,6 +26,7 @@ export interface StandardEngine {
   renderStyle(style: StyleObject): string;
   renderKeyframes(keyframes: KeyframesObject): string;
   renderFontFace(fontFace: FontFaceObject): string;
+  noopEngine?: boolean;
 }
 
 export function driver(style: StyleObject, styletron: StandardEngine): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,11 +1257,6 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -2138,11 +2133,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-js@^2.4.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
@@ -2190,14 +2180,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-context@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
-  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 create-universal-package@3.2.4:
   version "3.2.4"
@@ -2570,13 +2552,6 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 enhanced-resolve@^3.4.0:
   version "3.4.1"
@@ -3085,19 +3060,6 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fbjs@^0.8.0:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
-
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -3445,11 +3407,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
-
 handlebars@^4.0.2:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
@@ -3603,13 +3560,6 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.4:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@~0.4.13:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -4012,7 +3962,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4087,14 +4037,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
@@ -4809,14 +4751,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
   integrity sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -5360,13 +5294,6 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
-
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
 
 prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
@@ -5973,7 +5900,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -6567,11 +6494,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-ua-parser-js@^0.7.18:
-  version "0.7.19"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
-  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
-
 uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -6801,11 +6723,6 @@ webpack@^3.10.0:
     watchpack "^1.4.0"
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5413,15 +5413,15 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.6"
 
 react-is@^16.7.0:
   version "16.7.0"
@@ -5438,15 +5438,15 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.7.0"
     scheduler "^0.12.0"
 
-react@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
-  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
+react@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.6"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -5849,6 +5849,14 @@ scheduler@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
   integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
solves https://github.com/styletron/styletron/issues/256, https://github.com/styletron/styletron/issues/284#issuecomment-467194731

**EDIT: Descoped, explained [bellow](https://github.com/styletron/styletron/pull/304#issuecomment-479652251).**

# useStyletron

`useStyletron` is a React [hook](https://reactjs.org/docs/hooks-intro.html). 

This API introduces a very direct way of styling components (it's more discussed in https://github.com/styletron/styletron/issues/284#issuecomment-467194731). It should be handy for non-customizable components since it's pretty concise (no need to name the styled components) and prevents multiple pitfalls (ref forwarding, prop filtering...).

**It also supports theming**.

```jsx
import { Provider, useStyletron } from "styletron-react";

export default () => {
  const [ css ] = useStyletron();
  return (
    <div className={css({ color: 'blue' })}>Blue text</div>
  );
};
```

# No-op engine

If you forget to wrap your application with `<Provider>`, Styletron switches to a no-op mode and prints out a warning (instead of crashing). This is nice when writing tests. You don't need to setup Styletron if you don't care about styles. However, you should set `NODE_ENV = test` to prevent the warnings.

# Supporting only React 16.3+ / 16.8+

**This PR should be landed as a part of v5 milestone.** Why?

I believe it makes sense to drop the support for React v15 since v16 was released [18 months ago](https://github.com/facebook/react/releases/tag/v16.0.0). 

v16.3 introduces ref forwarding and createContext APIs. This PR removes `create-react-context` polyfill to save some bytes and we are going to implement ref forwarding in a few weeks as well. So 16.3+ is hard minimum.

If you want to use the `useStyletron` hook, you need to be on v16.8. Since it should be fairly easy to upgrade React from v16.3 to v16.8, I set the peerDependency to v16.8.

# Todos

- debugEngine is broken in the `useStyletron` API, I need to look more into how the whole thing works (I was not able to make the sourcemaps work yet even for the current version). Also, we could fix it later. 
- since this will be released as v5, docs will be updated later
