### PR TITLE
breaking: Replace $ref by React.forwardRef

### DIFF
--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -288,7 +288,7 @@ test("$-prefixed props not passed", t => {
   );
 });
 
-test("$ref", t => {
+test("ref forwarding", t => {
   t.plan(1);
 
   const Widget = styled("button", {color: "red"});
@@ -308,7 +308,7 @@ test("$ref", t => {
           }}
         >
           <Widget
-            $ref={c => {
+            ref={c => {
               this.widgetInner = c;
             }}
           />

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -471,7 +471,13 @@ export function createStyledElementComponent(styletron: Styletron) {
             const joined = `${debugClassName} ${elementProps.className}`;
             elementProps.className = joined;
           }
-          return <Element {...elementProps} ref={ref} />;
+          if (props.$ref) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              "The prop `$ref` has been deprecated. Use `ref` instead. Refs are now forwarded with React.forwardRef.",
+            );
+          }
+          return <Element {...elementProps} ref={ref || props.$ref} />;
         }}
       </Consumer>
     );

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -445,7 +445,7 @@ export function createStyledElementComponent(styletron: Styletron) {
     var debugClassName;
   }
 
-  function StyledElement(props) {
+  const StyledElement = React.forwardRef((props, ref) => {
     return (
       <Consumer>
         {(styletron, debugEngine, hydrating) => {
@@ -471,16 +471,11 @@ export function createStyledElementComponent(styletron: Styletron) {
             const joined = `${debugClassName} ${elementProps.className}`;
             elementProps.className = joined;
           }
-
-          if (props.$ref) {
-            elementProps.ref = props.$ref;
-          }
-
-          return <Element {...elementProps} />;
+          return <Element {...elementProps} ref={ref} />;
         }}
       </Consumer>
     );
-  }
+  });
 
   const Wrapped = wrapper(StyledElement);
   Wrapped.__STYLETRON__ = {


### PR DESCRIPTION
**This is a breaking change**. Motivation: 

- `$ref` was invented before native solution `React.forwardRef` existed
-   it removes one of the significant pitfalls since simple `ref` prop will just work after this change

Update for consumers should be as simple as doing `r/$ref/ref` globally. Afaik, there is no reason why would anyone wanted to get `ref` of the wrapper component (it doesn't even really work?).

Also, the React team has an intent to drop `React.forwardRef` and forward by default.

EDIT: [Apps](https://github.com/uber-web/baseui/blob/master/src/styles/styled.js#L14) implementing custom `styled` with `createStyled` might need to add additional `React.forwardRef` (the default wrapper is an identity function).