### PR TITLE
Alias withStyle to withStyleDeep, $style prop

### DIFF
--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -142,6 +142,108 @@ test("withStyle (dynamic)", t => {
   t.end();
 });
 
+test("$style prop (static)", t => {
+  t.plan(1);
+  const Widget = styled("div", {
+    lineHeight: 1,
+    color: "red",
+    ":hover": {fontSize: "12px"},
+  });
+
+  Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: x => {
+          t.deepEqual(x, {
+            color: "blue",
+            lineHeight: 1,
+            ":hover": {fontSize: "12px"},
+          });
+          return "";
+        },
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+    >
+      <Widget $style={{color: "blue"}} />
+    </Provider>,
+  );
+  t.end();
+});
+
+test("$style prop (dynamic)", t => {
+  t.plan(1);
+  const Widget = styled("div", {
+    lineHeight: 1,
+    color: "red",
+    ":hover": {fontSize: "12px"},
+  });
+
+  Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: x => {
+          t.deepEqual(x, {
+            color: "blue",
+            background: "yellow",
+            lineHeight: 1,
+            ":hover": {fontSize: "12px", borderWidth: 0},
+          });
+          return "";
+        },
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+    >
+      <Widget
+        $style={props => ({
+          color: "blue",
+          background: props.$round ? "yellow" : "green",
+          ":hover": {borderWidth: 0},
+        })}
+        $round={true}
+      />
+    </Provider>,
+  );
+  t.end();
+});
+
+test("$style overrides nested withStyle", t => {
+  t.plan(1);
+  const Widget = styled("div", {
+    color: "red",
+    fontSize: "12px",
+  });
+
+  const WidgetColor = withStyle(Widget, {color: "blue"});
+  const WidgetFontSize = withStyle(WidgetColor, {fontSize: "14px"});
+
+  Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: x => {
+          t.deepEqual(x, {
+            color: "yellow",
+            fontSize: "14px",
+            padding: "10px",
+          });
+          return "";
+        },
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+    >
+      <WidgetFontSize
+        $style={{
+          color: "yellow",
+          padding: "10px",
+        }}
+      />
+    </Provider>,
+  );
+  t.end();
+});
+
 test("withTransform", t => {
   t.plan(1);
   const Widget = styled("div", {color: "red", background: "green"});

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -10,7 +10,6 @@ import {
   createStyled,
   withWrapper,
   withStyle,
-  withStyleDeep,
   withTransform,
   Provider,
   useStyletron,
@@ -80,64 +79,12 @@ test("styled (dynamic)", t => {
 
 test("withStyle (static)", t => {
   t.plan(1);
-  const Widget = styled("div", {background: "green", color: "red"});
-  const SuperWidget = withStyle(Widget, {
-    color: "blue",
-    fontSize: "14px",
-  });
-  Enzyme.mount(
-    <Provider
-      value={{
-        renderStyle: x => {
-          t.deepEqual(x, {
-            background: "green",
-            color: "blue",
-            fontSize: "14px",
-          });
-          return "";
-        },
-        renderKeyframes: () => "",
-        renderFontFace: () => "",
-      }}
-    >
-      <SuperWidget />
-    </Provider>,
-  );
-  t.end();
-});
-
-test("withStyle (dynamic)", t => {
-  t.plan(1);
-  const Widget = styled("div", {color: "red", background: "yellow"});
-  const SuperWidget = withStyle(Widget, props => ({
-    background: props.$round ? "green" : "yellow",
-    fontSize: "14px",
-  }));
-  Enzyme.mount(
-    <Provider
-      value={{
-        renderStyle: x => {
-          t.deepEqual(x, {color: "red", background: "green", fontSize: "14px"});
-          return "";
-        },
-        renderKeyframes: () => "",
-        renderFontFace: () => "",
-      }}
-    >
-      <SuperWidget $round={true} />
-    </Provider>,
-  );
-  t.end();
-});
-
-test("withStyleDeep (static)", t => {
-  t.plan(1);
   const Widget = styled("div", {
     borderWidth: 0,
     color: "red",
     ":hover": {fontSize: "12px"},
   });
-  const SuperWidget = withStyleDeep(Widget, {
+  const SuperWidget = withStyle(Widget, {
     color: "blue",
     ":hover": {borderWidth: "10px"},
   });
@@ -162,14 +109,14 @@ test("withStyleDeep (static)", t => {
   t.end();
 });
 
-test("withStyleDeep (dynamic)", t => {
+test("withStyle (dynamic)", t => {
   t.plan(1);
   const Widget = styled("div", {
     lineHeight: 1,
     color: "red",
     ":hover": {fontSize: "12px"},
   });
-  const SuperWidget = withStyleDeep(Widget, props => ({
+  const SuperWidget = withStyle(Widget, props => ({
     background: props.$round ? "yellow" : "green",
     ":hover": {borderWidth: 0},
   }));

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -434,7 +434,15 @@ export function createStyledElementComponent(styletron: Styletron) {
           checkNoopEngine(styletron);
 
           const elementProps = omitPrefixedKeys(props);
-          const style = resolveStyle(getInitialStyle, reducers, props);
+          let style = resolveStyle(getInitialStyle, reducers, props);
+
+          if (props.$style) {
+            if (typeof props.$style === "function") {
+              style = deepMerge(style, props.$style(props));
+            } else {
+              style = deepMerge(style, props.$style);
+            }
+          }
 
           const styleClassString = driver(style, styletron);
           const Element = props.$as ? props.$as : base;

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -182,7 +182,7 @@ export function createStyled({
           "It appears you are passing a styled component into `styled`.",
         );
         console.warn(
-          "For composition with existing styled components, use `withStyle`, `withStyleDeep`, or `withTransform` instead.",
+          "For composition with existing styled components, use `withStyle` or `withTransform` instead.",
         );
         /* eslint-enable no-console */
       }
@@ -226,25 +226,7 @@ export function withTransform(component, transformer) {
 }
 
 declare var withStyle: WithStyleFn;
-export function withStyle(component, styleArg) {
-  const styletron = component.__STYLETRON__;
-
-  if (__DEV__) {
-    if (!styletron) {
-      /* eslint-disable no-console */
-      console.warn(
-        "The first parameter to `withStyle` must be a styled component (without extra wrappers).",
-      );
-      /* eslint-enable no-console */
-    }
-  }
-
-  if (__BROWSER__ && __DEV__) {
-    addDebugMetadata(styletron, 2);
-  }
-
-  return createStyledElementComponent(autoComposeShallow(styletron, styleArg));
-}
+export var withStyle = withStyleDeep;
 
 declare var withStyleDeep: WithStyleFn;
 export function withStyleDeep(component, styleArg) {
@@ -254,7 +236,7 @@ export function withStyleDeep(component, styleArg) {
     if (!styletron) {
       /* eslint-disable no-console */
       console.warn(
-        "The first parameter to `withStyleDeep` must be a styled component (without extra wrappers).",
+        "The first parameter to `withStyle` must be a styled component (without extra wrappers).",
       );
       /* eslint-enable no-console */
     }


### PR DESCRIPTION
Solves https://github.com/styletron/styletron/issues/221 and https://github.com/styletron/styletron/issues/284

## Alias `withStyle` to `withStyleDeep`

@rtsao:
> It has been brought up withStyle should be deep object merge because this is the common use case. I am inclined to agree with this, as specific transformations (such as replacements) should just use the more generic withTransform

This is a breaking change but in reality it should be pretty rare. `withStyleDeep` is unchanged and still exported, but it will be removed from the documentation since redundant. There is really no need to deprecate it.

## Direct style overrides through the `$style` prop 

```jsx
// Static
const Widget = styled("div", {color: "red"});
<Widget $style={{color: "blue"}} />
// result: { color: blue }

// Dynamic
const Widget = styled("div", {color:"red"});
<Widget $style={props => ({color: props.$info ? "blue" : "black"})} $info={true} />
// result: { color: blue }

// $style overrides even the withStyle
const Widget = withStyle(styled("div", {color: "red"}), {color: "yellow"});
<Widget $style={{color: "blue"}} />
// result: { color: blue }
```

The dynamic version of`$style` prop currently gets only `props`, so for style transforms you should still use the HoC `withTransform`. It's a pretty rare use-case and we could always add `style` later as a second parameter.

This API is very useful when implementing the [overrides pattern](https://baseweb.design/theming/understanding-overrides/). It would allow us to remove [this workaround](https://github.com/uber-web/baseui/blob/master/src/styles/styled.js#L34-L46). This can be a breaking change if you already use the `$style` prop for other purposes.