### PR TITLE
edits babel plugin files array to include source code

### DIFF
--- a/packages/babel-plugin-transform-styletron-display-name/package.json
+++ b/packages/babel-plugin-transform-styletron-display-name/package.json
@@ -9,7 +9,7 @@
     "test": "unitest --node=src/__tests__/test.node.js"
   },
   "files": [
-    "./src/index.js"
+    "src/index.js"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
[`v1.1.1` index file](https://unpkg.com/babel-plugin-transform-styletron-display-name@1.1.1/src/index.js)
[`v1.1.2` index file](https://unpkg.com/babel-plugin-transform-styletron-display-name@1.1.2/src/index.js) (does not exist)

neglected to properly test [this change](https://github.com/styletron/styletron/pull/299)
updated the `package.json` and verified source code is published by running `npm pack`

```
npm notice
npm notice 📦  babel-plugin-transform-styletron-display-name@1.1.2
npm notice === Tarball Contents ===
npm notice 578B  package.json
npm notice 630B  README.md
npm notice 2.5kB src/index.js
npm notice === Tarball Details ===
npm notice name:          babel-plugin-transform-styletron-display-name
npm notice version:       1.1.2
npm notice filename:      babel-plugin-transform-styletron-display-name-1.1.2.tgz
npm notice package size:  1.5 kB
npm notice unpacked size: 3.7 kB
npm notice shasum:        d663912ec04aaba068b6e38901ef96645c3d75d7
npm notice integrity:     sha512-OTr7T9GrZjrxI[...]3ctZlkFauEOgg==
npm notice total files:   3
npm notice
```