### PR TITLE
Bump inline-style-prefixer to 5.x

### DIFF
--- a/packages/devtools-extension/package.json
+++ b/packages/devtools-extension/package.json
@@ -1,5 +1,6 @@
 {
   "name": "styletron-devtools",
+  "private": true,
   "version": "0.0.1",
   "description": "Chrome devtools extension for inspecting Styletron styles",
   "author": "Jhey Tompkins <jhey@jhey.dev>",

--- a/packages/devtools-extension/package.json
+++ b/packages/devtools-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "styletron-devtools",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Chrome devtools extension for inspecting Styletron styles",
   "author": "Jhey Tompkins <jhey@jhey.dev>",
   "repository": "styletron/styletron",

--- a/packages/flow-type-tests/package.json
+++ b/packages/flow-type-tests/package.json
@@ -1,10 +1,10 @@
 {
   "name": "flow-type-tests",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "dependencies": {
-    "styletron-react": "^5.0.1",
+    "styletron-react": "^5.1.0",
     "styletron-standard": "^2.0.3"
   }
 }

--- a/packages/styletron-engine-atomic/package.json
+++ b/packages/styletron-engine-atomic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styletron-engine-atomic",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Universal, high-performance JavaScript styles",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "repository": "styletron/styletron",

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styletron-react",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "React bindings for Styletron",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "repository": "styletron/styletron",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,7 +3627,7 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
 
 inline-style-prefixer@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz#cb63195f9456dcda25cf59743e45c4d9815b0811"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz#cb63195f9456dcda25cf59743e45c4d9815b0811"
   integrity sha512-giteQHPMrApQOSjNSjteO5ZGSGMRf9gas14fRy2lg2buSc1nRnj6o6xuNds5cMTKrkncyrTu3gJn/yflFMVdmg==
   dependencies:
     css-in-js-utils "^2.0.0"


### PR DESCRIPTION
Newer versions of this package address more browser edge cases. We are
currently having issues with IE11's treatment of flex shorthand, which
we hope this will help resolve.