### PR TITLE
Fix forwarding of React.createRef() refs

### DIFF
--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -337,7 +337,7 @@ test("$-prefixed props not passed", t => {
   );
 });
 
-test("ref forwarding", t => {
+test("callback ref forwarding", t => {
   t.plan(1);
 
   const Widget = styled("button", {color: "red"});
@@ -361,6 +361,64 @@ test("ref forwarding", t => {
               this.widgetInner = c;
             }}
           />
+        </Provider>
+      );
+    }
+  }
+  Enzyme.mount(<TestComponent />);
+});
+
+test("React.createRef() ref forwarding", t => {
+  t.plan(1);
+
+  const Widget = styled("button", {color: "red"});
+  class TestComponent extends React.Component<{}> {
+    widgetInner: {current: null | HTMLButtonElement};
+
+    constructor(props: any) {
+      super(props);
+      this.widgetInner = React.createRef();
+    }
+
+    componentDidMount() {
+      t.ok(this.widgetInner.current instanceof HTMLButtonElement, "is button");
+    }
+
+    render() {
+      return (
+        <Provider
+          value={{
+            renderStyle: () => "",
+            renderKeyframes: () => "",
+            renderFontFace: () => "",
+          }}
+        >
+          <Widget ref={this.widgetInner} />
+        </Provider>
+      );
+    }
+  }
+  Enzyme.mount(<TestComponent />);
+});
+
+test("legacy string ref forwarding", t => {
+  t.plan(1);
+
+  const Widget = styled("button", {color: "red"});
+  class TestComponent extends React.Component<{}> {
+    componentDidMount() {
+      t.ok(this.refs.myButton instanceof HTMLButtonElement, "is button");
+    }
+    render() {
+      return (
+        <Provider
+          value={{
+            renderStyle: () => "",
+            renderKeyframes: () => "",
+            renderFontFace: () => "",
+          }}
+        >
+          <Widget ref="myButton" />
         </Provider>
       );
     }

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -373,12 +373,9 @@ test("React.createRef() ref forwarding", t => {
 
   const Widget = styled("button", {color: "red"});
   class TestComponent extends React.Component<{}> {
-    widgetInner: {current: null | HTMLButtonElement};
-
-    constructor(props: any) {
-      super(props);
-      this.widgetInner = React.createRef();
-    }
+    widgetInner: {
+      current: React.ElementRef<any> | null,
+    } = React.createRef();
 
     componentDidMount() {
       t.ok(this.widgetInner.current instanceof HTMLButtonElement, "is button");

--- a/packages/styletron-react/src/dev-tool.js
+++ b/packages/styletron-react/src/dev-tool.js
@@ -25,7 +25,11 @@ export const createDevtoolsRef = (extension, style, props, ref) => element => {
     }
   }
   if (ref) {
-    return ref(element);
+    if (typeof ref === "function") {
+      return ref(element);
+    }
+    ref.current = element;
+    return ref;
   }
 };
 // DEVTOOLS SETUP


### PR DESCRIPTION
Refs created with `React.createRef()` currently break `styletron-react` since they are not forwarded as functions into the devtool instrumentation. This PR fixes it and adds tests. Fortunately, legacy string refs are being transformed info functions by `React.forwardRef` so no change needed there. 

```js
if (ref) {
  if (typeof ref === "function") {
    return ref(element);
  }
  ref.current = element;
  return ref;
}
```

It looks a bit iffy but it seems this is the [only way](https://github.com/facebook/react/issues/13029) to compose refs created by `createRef()`.

cc @jh3y