### PR TITLE
Fix refs again

### DIFF
--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
+    "react-is": "^16.8.6",
     "styletron-standard": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -707,6 +707,7 @@ test("canAcceptRef", t => {
   const LazyComponent = React.lazy(() => Component);
   const MemoComponent = React.memo(Component);
   const Context = React.createContext(false);
+  t.ok(canAcceptRef("div"), "string component accepts refs");
   t.ok(canAcceptRef(Component), "class component accepts refs");
   t.ok(
     !canAcceptRef(FunctionComponent),

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -3,6 +3,7 @@
 import test from "tape";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+import {canAcceptRef} from "../dev-tool";
 import * as React from "react";
 
 import {
@@ -689,5 +690,33 @@ test("no-op engine", t => {
   Enzyme.mount(<Widget />);
 
   (console: any).warn = consoleWarn;
+  t.end();
+});
+
+test("canAcceptRef", t => {
+  class Component extends React.Component<{}> {
+    render() {
+      return React.createElement("div");
+    }
+  }
+  const FunctionComponent = () => React.createElement("div");
+  const ForwardRefComponent = React.forwardRef((props, ref) =>
+    React.createElement(Component, {forwardedRef: ref, ...props}),
+  );
+  //$FlowFixMe
+  const LazyComponent = React.lazy(() => Component);
+  const MemoComponent = React.memo(Component);
+  const Context = React.createContext(false);
+  t.ok(canAcceptRef(Component), "class component accepts refs");
+  t.ok(
+    !canAcceptRef(FunctionComponent),
+    "function component doesn't accept refs",
+  );
+  t.ok(canAcceptRef(ForwardRefComponent), "forwardRef component accepts refs");
+  t.ok(!canAcceptRef(LazyComponent), "lazy component doesn't accept refs");
+  t.ok(!canAcceptRef(MemoComponent), "memo component doesn't accept refs");
+  t.ok(!canAcceptRef(Context.Provider), "context provider doesn't accept refs");
+  t.ok(!canAcceptRef(Context.Consumer), "context consumer doesn't accept refs");
+  t.ok(!canAcceptRef(Context.Provider), "context provider doesn't accept refs");
   t.end();
 });

--- a/packages/styletron-react/src/dev-tool.js
+++ b/packages/styletron-react/src/dev-tool.js
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 /* global module */
 import * as React from "react";
-import * as ReactIs from "react-is";
+import {isForwardRef} from "react-is";
 
 export function addDebugMetadata(instance, stackIndex) {
   const {stack, stacktrace, message} = new Error("stacktrace source");

--- a/packages/styletron-react/src/dev-tool.js
+++ b/packages/styletron-react/src/dev-tool.js
@@ -12,6 +12,9 @@ export function addDebugMetadata(instance, stackIndex) {
 }
 
 export function canAcceptRef(Component) {
+  if (typeof Component === "string") {
+    return true;
+  }
   if (ReactIs.isForwardRef(<Component />)) {
     return true;
   }

--- a/packages/styletron-react/src/dev-tool.js
+++ b/packages/styletron-react/src/dev-tool.js
@@ -15,7 +15,7 @@ export function canAcceptRef(Component) {
   if (typeof Component === "string") {
     return true;
   }
-  if (ReactIs.isForwardRef(<Component />)) {
+  if (isForwardRef(<Component />)) {
     return true;
   }
   if (Component.prototype && Component.prototype.isReactComponent) {

--- a/packages/styletron-react/src/dev-tool.js
+++ b/packages/styletron-react/src/dev-tool.js
@@ -1,5 +1,7 @@
 /* eslint-env browser */
 /* global module */
+import * as React from "react";
+import * as ReactIs from "react-is";
 
 export function addDebugMetadata(instance, stackIndex) {
   const {stack, stacktrace, message} = new Error("stacktrace source");
@@ -7,6 +9,16 @@ export function addDebugMetadata(instance, stackIndex) {
     stackInfo: {stack, stacktrace, message},
     stackIndex: stackIndex,
   };
+}
+
+export function canAcceptRef(Component) {
+  if (ReactIs.isForwardRef(<Component />)) {
+    return true;
+  }
+  if (Component.prototype && Component.prototype.isReactComponent) {
+    return true;
+  }
+  return false;
 }
 
 export const createDevtoolsRef = (extension, style, props, ref) => element => {

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -31,6 +31,7 @@ import {
   createDevtoolsRef,
   setupDevtoolsExtension,
   DebugEngine,
+  canAcceptRef,
 } from "./dev-tool.js";
 
 export {DebugEngine};
@@ -488,8 +489,18 @@ export function createStyledElementComponent(styletron: Styletron) {
             elementProps.className = joined;
           }
 
-          if (__BROWSER__ && __DEV__ && window.__STYLETRON_DEVTOOLS__) {
-            elementProps.ref = createDevtoolsRef(ext, style, props, ref);
+          if (
+            __BROWSER__ &&
+            __DEV__ &&
+            window.__STYLETRON_DEVTOOLS__ &&
+            canAcceptRef(Element)
+          ) {
+            elementProps.ref = createDevtoolsRef(
+              ext,
+              style,
+              props,
+              ref || props.$ref,
+            );
           }
 
           if (props.$ref) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,6 +5428,11 @@ react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
+react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-test-renderer@^16.0.0-0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.7.0.tgz#1ca96c2b450ab47c36ba92cd8c03fcefc52ea01c"


### PR DESCRIPTION
We need to detect if underlying component can deal with ref aka:

- it forwards them
- it is a class component
- `string` like `div` or `button` is being passed / created

Also, `$ref` was never passed through in the DEV mode.