### PR TITLE
updates to flow v0.100

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.92.0",
+    "flow-bin": "^0.100.0",
     "lerna": "^2.11.0",
     "prettier": "^1.13.7"
   },

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -429,7 +429,8 @@ export function composeDynamic<Props>(
     base: styletron.base,
     driver: styletron.driver,
     wrapper: styletron.wrapper,
-    reducers: [{assignmentCommutative: false, reducer}].concat(
+    // safely casts to any because reducer is type checked in the function arguments
+    reducers: [{assignmentCommutative: false, reducer: (reducer: any)}].concat(
       styletron.reducers,
     ),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,10 +3121,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.92.0:
-  version "0.92.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.92.0.tgz#f5bf3e808b17b480e067ac673829ca715a168bea"
-  integrity sha512-3ErXSAXZZlLV5/QPlaUDCWlDUXop1SiH32ifXL3SEiBwsmGbudCLim+HFVZfkegrn1nB4TcNSkMWtW8SnMPyAQ==
+flow-bin@^0.100.0:
+  version "0.100.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.100.0.tgz#729902726658cfa0a81425d6401f9625cf9f5534"
+  integrity sha512-jcethhgrslBJukH7Z7883ohFFpzLrdsOEwHxvn5NwuTWbNaE71GAl55/PEBRJwYpDvYkRlqgcNkANTv0x5XjqA==
 
 for-each@~0.3.3:
   version "0.3.3"


### PR DESCRIPTION
Consumers of styletron that have updated to flow v0.100 are seeing this error locally. I spent a decent amount of time trying to pinpoint why exactly flow check failed here, but no real luck. I believe the cast to any is safe in this situation since we've already validated the type in the input position. Original error below.

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/styletron-react/src/index.js:432:47

Cannot assign object literal to composed because function type [1] requires another argument from function type [2] in
property reducer of array element of property reducers.

     node_modules/styletron-react/src/index.js
     424│   styletron: Styletron,
 [1] 425│   reducer: (StyleObject, Props) => StyleObject,
     426│ ) {
     427│   const composed: Styletron = {
     428│     getInitialStyle: styletron.getInitialStyle,
     429│     base: styletron.base,
     430│     driver: styletron.driver,
     431│     wrapper: styletron.wrapper,
     432│     reducers: [{assignmentCommutative: false, reducer}].concat(
     433│       styletron.reducers,
     434│     ),
     435│   };
     436│   if (__BROWSER__ && __DEV__) {
     437│     composed.debug = styletron.debug;
     438│   }

     node_modules/styletron-react/src/types.js
 [2]  12│   (StyleObject): StyleObject,
```