### PR TITLE
Improve typing of styletron-react internals

### DIFF
--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -20,7 +20,6 @@ import type {
   ReducerContainer,
   AssignmentCommutativeReducerContainer,
   NonAssignmentCommutativeReducerContainer,
-  Reducer,
   StyledFn,
   WithStyleFn,
   WithTransformFn,
@@ -377,10 +376,10 @@ export function createDeepMergeReducer(
 
 export function composeStatic(
   styletron: Styletron,
-  reducerContainer: ReducerContainer,
+  reducerContainer: AssignmentCommutativeReducerContainer,
 ) {
   if (styletron.reducers.length === 0) {
-    const style = reducerContainer.reducer(styletron.getInitialStyle(), {});
+    const style = reducerContainer.reducer(styletron.getInitialStyle());
     const result: Styletron = {
       reducers: styletron.reducers,
       base: styletron.base,
@@ -430,7 +429,7 @@ export function composeDynamic<Props>(
     driver: styletron.driver,
     wrapper: styletron.wrapper,
     // safely casts to any because reducer is type checked in the function arguments
-    reducers: [{assignmentCommutative: false, reducer: (reducer: any)}].concat(
+    reducers: [{assignmentCommutative: false, reducer: reducer}].concat(
       styletron.reducers,
     ),
   };
@@ -559,7 +558,10 @@ export function resolveStyle(
   let result = getInitialStyle();
   let i = reducers.length;
   while (i--) {
-    result = reducers[i].reducer(result, props);
+    const reducer = reducers[i];
+    result = reducer.assignmentCommutative
+      ? reducer.reducer(result)
+      : reducer.reducer(result, props);
   }
   return result;
 }

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -553,14 +553,13 @@ export function resolveStyle(
   getInitialStyle: void => StyleObject,
   reducers: Array<ReducerContainer>,
   props: Object,
-) {
+): StyleObject {
   let result = getInitialStyle();
   let i = reducers.length;
   while (i--) {
-    const reducer = reducers[i];
-    result = reducer.assignmentCommutative
-      ? reducer.reducer(result)
-      : reducer.reducer(result, props);
+    // Cast to allow passing unused props param in case of static reducer
+    const reducer /*: any */ = reducers[i].reducer;
+    result = reducer(result, props);
   }
   return result;
 }

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -429,7 +429,7 @@ export function composeDynamic<Props>(
     driver: styletron.driver,
     wrapper: styletron.wrapper,
     // safely casts to any because reducer is type checked in the function arguments
-    reducers: [{assignmentCommutative: false, reducer: reducer}].concat(
+    reducers: [{assignmentCommutative: false, reducer}].concat(
       styletron.reducers,
     ),
   };

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -558,7 +558,7 @@ export function resolveStyle(
   let i = reducers.length;
   while (i--) {
     // Cast to allow passing unused props param in case of static reducer
-    const reducer /*: any */ = reducers[i].reducer;
+    const reducer = (reducers[i].reducer: (StyleObject, Object) => StyleObject);
     result = reducer(result, props);
   }
   return result;

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -428,7 +428,6 @@ export function composeDynamic<Props>(
     base: styletron.base,
     driver: styletron.driver,
     wrapper: styletron.wrapper,
-    // safely casts to any because reducer is type checked in the function arguments
     reducers: [{assignmentCommutative: false, reducer}].concat(
       styletron.reducers,
     ),

--- a/packages/styletron-react/src/types.js
+++ b/packages/styletron-react/src/types.js
@@ -7,23 +7,16 @@ import type {
 } from "react";
 import type {StyleObject} from "styletron-standard";
 
-export type Reducer = {
-  // Static reducer
-  (StyleObject): StyleObject,
-  // Dynamic reducer
-  (StyleObject, Object): StyleObject,
-};
-
 export type AssignmentCommutativeReducerContainer = {
   assignmentCommutative: true,
-  reducer: Reducer,
+  reducer: StyleObject => StyleObject,
   style: StyleObject,
   factory: StyleObject => AssignmentCommutativeReducerContainer,
 };
 
 export type NonAssignmentCommutativeReducerContainer = {
   assignmentCommutative: false,
-  reducer: Reducer,
+  reducer: (StyleObject, Object) => StyleObject,
 };
 
 export type ReducerContainer =


### PR DESCRIPTION
The reducer container type is a disjoint union to allow for refinements.

That said, internal type safety might not be worth it for the runtime cost of this check. At the very least, this is a good starting place for doing a more limited, precise casting (as opposed to `any`).