### PR TITLE
Use className instead of element as the identifier for Chrome extension

### DIFF
--- a/packages/devtools-extension/devtools_script.js
+++ b/packages/devtools-extension/devtools_script.js
@@ -4,15 +4,18 @@ const elementsPanel = panels.elements;
 
 elementsPanel.createSidebarPane("Styletron", sidebar => {
   elementsPanel.onSelectionChanged.addListener(() => {
-    inspectedWindow.eval("__STYLETRON_DEVTOOLS__.getStyles($0)", (res, err) => {
-      if (err && err.isError) {
-        throw new Error(`Styletron devtools: ${err.description}`);
-      }
-      if (res) {
-        sidebar.setObject(res, "Styletron Styles");
-      } else {
-        sidebar.setObject(null, "Not a styled element");
-      }
-    });
+    inspectedWindow.eval(
+      "__STYLETRON_DEVTOOLS__.getStyles($0.className)",
+      (res, err) => {
+        if (err && err.isError) {
+          throw new Error(`Styletron devtools: ${err.description}`);
+        }
+        if (res) {
+          sidebar.setObject(res, "Styletron Styles");
+        } else {
+          sidebar.setObject(null, "Not a styledddd element");
+        }
+      },
+    );
   });
 });

--- a/packages/devtools-extension/devtools_script.js
+++ b/packages/devtools-extension/devtools_script.js
@@ -13,7 +13,7 @@ elementsPanel.createSidebarPane("Styletron", sidebar => {
         if (res) {
           sidebar.setObject(res, "Styletron Styles");
         } else {
-          sidebar.setObject(null, "Not a styledddd element");
+          sidebar.setObject(null, "Not a styled element");
         }
       },
     );

--- a/packages/devtools-extension/manifest.json
+++ b/packages/devtools-extension/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name":"styletron-devtools",
-  "version": "0.0.1",
+  "name": "styletron-devtools",
+  "version": "0.1.0",
   "manifest_version": 2,
   "description": "Inspect styletron styles",
   "icons": {

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-is": "^16.8.6",
     "styletron-standard": "^2.0.4"
   },
   "peerDependencies": {

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -399,6 +399,30 @@ test("React.createRef() ref forwarding", t => {
   Enzyme.mount(<TestComponent />);
 });
 
+test("React.useRef() ref forwarding", t => {
+  t.plan(1);
+  const Widget = styled("button", {color: "red"});
+  const TestComponent = () => {
+    const widgetInner = React.useRef(null);
+    React.useEffect(() => {
+      t.ok(widgetInner.current instanceof HTMLButtonElement, "is button");
+    }, []);
+    return (
+      <Provider
+        value={{
+          renderStyle: () => "",
+          renderKeyframes: () => "",
+          renderFontFace: () => "",
+        }}
+      >
+        <Widget ref={widgetInner} />
+      </Provider>
+    );
+  };
+
+  Enzyme.mount(<TestComponent />);
+});
+
 test("legacy string ref forwarding", t => {
   t.plan(1);
 

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -716,32 +716,3 @@ test("no-op engine", t => {
   (console: any).warn = consoleWarn;
   t.end();
 });
-
-test("canAcceptRef", t => {
-  class Component extends React.Component<{}> {
-    render() {
-      return React.createElement("div");
-    }
-  }
-  const FunctionComponent = () => React.createElement("div");
-  const ForwardRefComponent = React.forwardRef((props, ref) =>
-    React.createElement(Component, {forwardedRef: ref, ...props}),
-  );
-  //$FlowFixMe
-  const LazyComponent = React.lazy(() => Component);
-  const MemoComponent = React.memo(Component);
-  const Context = React.createContext(false);
-  t.ok(canAcceptRef("div"), "string component accepts refs");
-  t.ok(canAcceptRef(Component), "class component accepts refs");
-  t.ok(
-    !canAcceptRef(FunctionComponent),
-    "function component doesn't accept refs",
-  );
-  t.ok(canAcceptRef(ForwardRefComponent), "forwardRef component accepts refs");
-  t.ok(!canAcceptRef(LazyComponent), "lazy component doesn't accept refs");
-  t.ok(!canAcceptRef(MemoComponent), "memo component doesn't accept refs");
-  t.ok(!canAcceptRef(Context.Provider), "context provider doesn't accept refs");
-  t.ok(!canAcceptRef(Context.Consumer), "context consumer doesn't accept refs");
-  t.ok(!canAcceptRef(Context.Provider), "context provider doesn't accept refs");
-  t.end();
-});

--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -3,7 +3,6 @@
 import test from "tape";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import {canAcceptRef} from "../dev-tool";
 import * as React from "react";
 
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5422,11 +5422,6 @@ react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
-react-is@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
-
 react-test-renderer@^16.0.0-0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.7.0.tgz#1ca96c2b450ab47c36ba92cd8c03fcefc52ea01c"


### PR DESCRIPTION
In the dev mode, `styletron-react` creates a global data-structure (map) that is consumed by our Chrome extension. It maps elements (DOM nodes) to the styles meta-data. In order to get DOM nodes in styletron-react, we use [refs](https://reactjs.org/docs/refs-and-the-dom.html). Unfortunately, it causes multiple issues.

It seems we can just use `className` attribute as our key instead of the element since there's a direct relation between that and resulting styles. That means no refs and messy workarounds!

There is one edge-case that can happen: Two different styled components having different initial styles but resulting into the same style-set because of `withStyle` overrides. Then, you could get a partly incorrect info in the devtools. However, if you also use the `debug` mode (enabled by default in most of apps), the className also includes the `__debugX` class that is always unique and prevents this edge-case. So I think we don't have to worry about it. 

I've also added test for `React.useRef()` forwarding.