### PR TITLE
typescript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "lint": "eslint --ignore-path .gitignore .",
-    "pretest": "yarn run lint && yarn run flow",
+    "pretest": "yarn run lint && yarn run flow && yarn run tscheck",
     "test": "lerna run test",
     "build": "lerna run build",
     "flow": "flow --max-warnings=0",
+    "tscheck": "tsc -p . --noEmit",
     "publish": "lerna publish --npm-client=npm",
     "playground": "lerna run --scope playground dev --stream"
   },
@@ -25,7 +26,8 @@
     "eslint-plugin-react": "^7.14.3",
     "flow-bin": "^0.110.0",
     "lerna": "^2.11.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "typescript": "^3.6.2"
   },
   "license": "MIT"
 }

--- a/packages/styletron-engine-atomic/package.json
+++ b/packages/styletron-engine-atomic/package.json
@@ -23,6 +23,7 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
+  "types": "./src/index.d.ts",
   "scripts": {
     "build": "cup build --force-flow",
     "pretest": "cup build-tests",

--- a/packages/styletron-engine-atomic/src/cache.d.ts
+++ b/packages/styletron-engine-atomic/src/cache.d.ts
@@ -1,0 +1,26 @@
+import SequentialIDGenerator from "./sequential-id-generator";
+declare type OnNewCacheFn<T> = (c: string, b: Cache<T>, a?: string | null) => any;
+declare type OnNewValueFn<T> = (cache: Cache<T>, id: string, value: T) => any;
+export declare class MultiCache<T> {
+    caches: {
+        [x: string]: Cache<T>;
+    };
+    idGenerator: SequentialIDGenerator;
+    onNewCache: OnNewCacheFn<T>;
+    onNewValue: OnNewValueFn<T>;
+    sortedCacheKeys: string[];
+    constructor(idGenerator: SequentialIDGenerator, onNewCache: OnNewCacheFn<T>, onNewValue: OnNewValueFn<T>);
+    getCache(key: string): Cache<T>;
+    getSortedCacheKeys(): string[];
+}
+export declare class Cache<T> {
+    cache: {
+        [x: string]: string;
+    };
+    idGenerator: SequentialIDGenerator;
+    key: string;
+    onNewValue: (cache: Cache<T>, id: string, value: any) => any;
+    constructor(idGenerator: SequentialIDGenerator, onNewValue: (cache: Cache<T>, id: string, value: any) => any);
+    addValue(key: string, value: T): string;
+}
+export {};

--- a/packages/styletron-engine-atomic/src/client/client.d.ts
+++ b/packages/styletron-engine-atomic/src/client/client.d.ts
@@ -1,0 +1,27 @@
+import { StandardEngine, KeyframesObject, FontFaceObject, StyleObject } from "styletron-standard";
+import { Cache, MultiCache } from "../cache";
+declare type hydrateT = HTMLCollectionOf<HTMLStyleElement> | Array<HTMLStyleElement> | NodeListOf<HTMLStyleElement>;
+declare type optionsT = {
+    hydrate?: hydrateT;
+    container?: Element;
+    prefix?: string;
+};
+declare class StyletronClient implements StandardEngine {
+    container: Element;
+    styleElements: {
+        [x: string]: HTMLStyleElement;
+    };
+    fontFaceSheet: HTMLStyleElement;
+    keyframesSheet: HTMLStyleElement;
+    styleCache: MultiCache<{
+        pseudo: string;
+        block: string;
+    }>;
+    keyframesCache: Cache<KeyframesObject>;
+    fontFaceCache: Cache<FontFaceObject>;
+    constructor(opts?: optionsT);
+    renderStyle(style: StyleObject): string;
+    renderFontFace(fontFace: FontFaceObject): string;
+    renderKeyframes(keyframes: KeyframesObject): string;
+}
+export default StyletronClient;

--- a/packages/styletron-engine-atomic/src/css.d.ts
+++ b/packages/styletron-engine-atomic/src/css.d.ts
@@ -1,0 +1,8 @@
+export declare function atomicSelector(id: string, pseudo: string): string;
+export declare function keyframesToBlock(keyframes: {
+    [x: string]: any;
+}): string;
+export declare function declarationsToBlock(style: any): string;
+export declare function keyframesBlockToRule(id: string, block: string): string;
+export declare function fontFaceBlockToRule(id: string, block: string): string;
+export declare function styleBlockToRule(selector: string, block: string): string;

--- a/packages/styletron-engine-atomic/src/dev-tool.d.ts
+++ b/packages/styletron-engine-atomic/src/dev-tool.d.ts
@@ -1,0 +1,2 @@
+export declare const insertRuleIntoDevtools: (selector: any, block: any) => void;
+export declare const hydrateDevtoolsRule: (cssString: any) => void;

--- a/packages/styletron-engine-atomic/src/hyphenate-style-name.d.ts
+++ b/packages/styletron-engine-atomic/src/hyphenate-style-name.d.ts
@@ -1,0 +1,1 @@
+export default function hyphenateStyleName(prop: string): string;

--- a/packages/styletron-engine-atomic/src/index.d.ts
+++ b/packages/styletron-engine-atomic/src/index.d.ts
@@ -1,0 +1,7 @@
+declare global {
+    interface Window {
+        __STYLETRON_DEVTOOLS__: any;
+    }
+}
+export { default as Client } from "./client/client";
+export { default as Server } from "./server/server";

--- a/packages/styletron-engine-atomic/src/inject-style-prefixed.d.ts
+++ b/packages/styletron-engine-atomic/src/inject-style-prefixed.d.ts
@@ -1,0 +1,6 @@
+import { StyleObject } from "styletron-standard";
+import { MultiCache } from "./cache";
+export default function injectStylePrefixed(styleCache: MultiCache<{
+    pseudo: string;
+    block: string;
+}>, styles: StyleObject, media: string, pseudo: string): string;

--- a/packages/styletron-engine-atomic/src/sequential-id-generator.d.ts
+++ b/packages/styletron-engine-atomic/src/sequential-id-generator.d.ts
@@ -1,0 +1,10 @@
+export default class SequentialIDGenerator {
+    prefix: string;
+    count: number;
+    offset: number;
+    msb: number;
+    power: number;
+    constructor(prefix?: string);
+    next(): string;
+    increment(): number;
+}

--- a/packages/styletron-engine-atomic/src/server/server.d.ts
+++ b/packages/styletron-engine-atomic/src/server/server.d.ts
@@ -1,0 +1,37 @@
+import { StandardEngine } from "styletron-standard";
+import { Cache, MultiCache } from "../cache";
+import { StyleObject, FontFaceObject, KeyframesObject } from "styletron-standard";
+export declare type attrsT = {
+    "data-hydrate"?: "keyframes" | "font-face";
+    media?: string;
+    class?: string;
+};
+export declare type sheetT = {
+    css: string;
+    attrs: attrsT;
+};
+declare type optionsT = {
+    prefix?: string;
+};
+declare class StyletronServer implements StandardEngine {
+    styleCache: MultiCache<{
+        pseudo: string;
+        block: string;
+    }>;
+    keyframesCache: Cache<KeyframesObject>;
+    fontFaceCache: Cache<FontFaceObject>;
+    styleRules: {
+        [x: string]: string;
+    };
+    keyframesRules: string;
+    fontFaceRules: string;
+    constructor(opts?: optionsT);
+    renderStyle(style: StyleObject): string;
+    renderFontFace(fontFace: FontFaceObject): string;
+    renderKeyframes(keyframes: KeyframesObject): string;
+    getStylesheets(): Array<sheetT>;
+    getStylesheetsHtml(className?: string): string;
+    getCss(): string;
+}
+export declare function generateHtmlString(sheets: Array<sheetT>, className: string): string;
+export default StyletronServer;

--- a/packages/styletron-engine-atomic/src/sort-css-media-queries.d.ts
+++ b/packages/styletron-engine-atomic/src/sort-css-media-queries.d.ts
@@ -1,0 +1,1 @@
+export default function sortCSSmq(a: string, b: string): number;

--- a/packages/styletron-engine-atomic/src/validate-keyframes-object.d.ts
+++ b/packages/styletron-engine-atomic/src/validate-keyframes-object.d.ts
@@ -1,0 +1,1 @@
+export default function validateKeyframesObject(keyframes: any): void;

--- a/packages/styletron-engine-atomic/src/validate-no-mixed-hand.d.ts
+++ b/packages/styletron-engine-atomic/src/validate-no-mixed-hand.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Adapted from https://github.com/gilmoreorless/css-shorthand-properties
+ */
+export declare function validateNoMixedHand(style: any): any[];

--- a/packages/styletron-engine-atomic/tsconfig.json
+++ b/packages/styletron-engine-atomic/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -23,6 +23,7 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
+  "types": "./src/index.d.ts",
   "scripts": {
     "build": "cup build --force-flow",
     "pretest": "cup build-tests",

--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -35,10 +35,13 @@
     "styletron-standard": "^3.0.4"
   },
   "peerDependencies": {
+    "@types/react": "^16.8.23",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.0.0-beta.56",
+    "@types/react": "^16.8.23",
+    "@types/webpack-env": "^1.13.9",
     "create-universal-package": "3.2.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/packages/styletron-react/src/dev-tool.d.ts
+++ b/packages/styletron-react/src/dev-tool.d.ts
@@ -1,0 +1,19 @@
+export declare function addDebugMetadata(instance: any, stackIndex: any): void;
+export declare const setupDevtoolsExtension: () => void;
+declare class BrowserDebugEngine {
+    private worker;
+    private counter;
+    constructor(worker: any);
+    debug({ stackIndex, stackInfo }: {
+        stackIndex: any;
+        stackInfo: any;
+    }): string;
+}
+declare class NoopDebugEngine {
+    debug(): void;
+}
+declare global {
+    var __BROWSER__: boolean;
+}
+export declare const DebugEngine: typeof BrowserDebugEngine | typeof NoopDebugEngine;
+export {};

--- a/packages/styletron-react/src/index.d.ts
+++ b/packages/styletron-react/src/index.d.ts
@@ -1,0 +1,53 @@
+declare global {
+    interface Window {
+        __STYLETRON_DEVTOOLS__: any;
+    }
+}
+import * as React from "react";
+import { driver, StandardEngine, StyleObject } from "styletron-standard";
+import { Styletron, ReducerContainer, AssignmentCommutativeReducerContainer, StyledFn, WithStyleFn, WithTransformFn, WithWrapperFn, StyletronProps } from "./types";
+import { DebugEngine } from "./dev-tool";
+export { DebugEngine };
+export { StyleObject };
+export { StyletronProps };
+declare type DevProviderProps = {
+    children: React.ReactNode;
+    value: StandardEngine;
+    debugAfterHydration?: boolean;
+    debug?: any;
+};
+declare class DevProvider extends React.Component<DevProviderProps, {
+    hydrating: boolean;
+}> {
+    constructor(props: DevProviderProps);
+    componentDidMount(): void;
+    render(): JSX.Element;
+}
+export declare const Provider: typeof DevProvider | React.ProviderExoticComponent<React.ProviderProps<StandardEngine>>;
+export declare function DevConsumer(props: {
+    children: (c: any, b: any, a: any) => React.ReactNode;
+}): JSX.Element;
+declare type createStyledOpts = {
+    getInitialStyle: () => StyleObject;
+    driver: typeof driver;
+    wrapper: (a: React.FC<any>) => React.ComponentType<any>;
+};
+export declare function useStyletron(): ((style: StyleObject) => string)[];
+export declare function createStyled({ getInitialStyle, driver, wrapper, }: createStyledOpts): StyledFn;
+export declare const styled: StyledFn;
+export declare const withTransform: WithTransformFn;
+export declare const withStyleDeep: WithStyleFn;
+export declare const withStyle: WithStyleFn;
+export declare const withWrapper: WithWrapperFn;
+export declare function autoComposeShallow<Props>(styletron: Styletron, styleArg: StyleObject | ((a: Props) => StyleObject)): Styletron;
+export declare function autoComposeDeep<Props>(styletron: Styletron, styleArg: StyleObject | ((a: Props) => StyleObject)): Styletron;
+export declare function staticComposeShallow(styletron: Styletron, style: StyleObject): Styletron;
+export declare function staticComposeDeep(styletron: Styletron, style: StyleObject): Styletron;
+export declare function dynamicComposeShallow<Props>(styletron: Styletron, styleFn: (a: Props) => StyleObject): Styletron;
+export declare function dynamicComposeDeep<Props>(styletron: Styletron, styleFn: (a: Props) => StyleObject): Styletron;
+export declare function createShallowMergeReducer(style: StyleObject): AssignmentCommutativeReducerContainer;
+export declare function createDeepMergeReducer(style: StyleObject): AssignmentCommutativeReducerContainer;
+export declare function composeStatic(styletron: Styletron, reducerContainer: AssignmentCommutativeReducerContainer): Styletron;
+export declare function composeDynamic<Props>(styletron: Styletron, reducer: (b: StyleObject, a: Props) => StyleObject): Styletron;
+export declare function createStyledElementComponent(styletron: Styletron): any;
+export declare function resolveStyle(getInitialStyle: (a: void) => StyleObject, reducers: Array<ReducerContainer>, props: any): StyleObject;

--- a/packages/styletron-react/src/types.d.ts
+++ b/packages/styletron-react/src/types.d.ts
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { ComponentType } from "react";
+import { StyleObject } from "styletron-standard";
+export declare type AssignmentCommutativeReducerContainer = {
+    assignmentCommutative: true;
+    reducer: (a: StyleObject) => StyleObject;
+    style: StyleObject;
+    factory: (a: StyleObject) => AssignmentCommutativeReducerContainer;
+};
+export declare type NonAssignmentCommutativeReducerContainer = {
+    assignmentCommutative: false;
+    reducer: (b: StyleObject, a: any) => StyleObject;
+};
+export declare type ReducerContainer = AssignmentCommutativeReducerContainer | NonAssignmentCommutativeReducerContainer;
+export declare type Styletron = {
+    reducers: Array<ReducerContainer>;
+    base: any;
+    driver: any;
+    name?: string;
+    wrapper: any;
+    getInitialStyle: any;
+    ext?: {
+        name?: string;
+        base: any;
+        getInitialStyle: any;
+        with: any;
+    };
+    debug?: {
+        stackIndex: number;
+        stackInfo: {
+            stack: any;
+            stacktrace: any;
+            message: any;
+        };
+    };
+};
+export declare type StyletronProps<Props = {}> = Partial<{
+    $style: StyleObject | ((props: Props) => StyleObject);
+    $as: ComponentType<any> | keyof JSX.IntrinsicElements;
+    className: string;
+    /** @deprecated */
+    $ref: Props extends {
+        ref?: infer T;
+    } ? T : React.Ref<any>;
+    ref: Props extends {
+        ref?: infer T;
+    } ? T : React.Ref<any>;
+}>;
+export declare type StyletronComponent<Props> = React.FC<Props & StyletronProps<Props>> & {
+    __STYLETRON__: any;
+};
+export declare type StyledFn = {
+    <T extends keyof JSX.IntrinsicElements | ComponentType<any>, Props>(component: T, style: StyleObject | ((a: Props) => StyleObject)): StyletronComponent<(T extends ComponentType<infer BaseProps> ? BaseProps : T extends keyof JSX.IntrinsicElements ? JSX.IntrinsicElements[T] : {}) & Props>;
+};
+export declare type WithStyleFn = {
+    <Base extends StyletronComponent<any>, Props = {}>(comnponent: Base, a: StyleObject | ((a: Props) => StyleObject)): StyletronComponent<(Base extends StyletronComponent<infer BaseProps> ? BaseProps : never) & Props>;
+};
+export declare type WithTransformFn = <Base extends StyletronComponent<any>, Props>(b: Base, a: (b: StyleObject, a: Props) => StyleObject) => StyletronComponent<(Base extends StyletronComponent<infer BaseProps> ? BaseProps : never) & Props>;
+export declare type WithWrapperFn = <Base extends StyletronComponent<any>, Props>(component: Base, wrapper: (a: Base) => ComponentType<Props>) => StyletronComponent<(Base extends StyletronComponent<infer BaseProps> ? BaseProps : never) & Props>;

--- a/packages/styletron-react/tsconfig.json
+++ b/packages/styletron-react/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -23,6 +23,7 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
+  "types": "./src/index.d.ts",
   "scripts": {
     "build": "cup build --force-flow",
     "pretest": "cup build-tests",

--- a/packages/styletron-standard/src/index.d.ts
+++ b/packages/styletron-standard/src/index.d.ts
@@ -1,0 +1,14 @@
+import { Properties, FontFace as FontFaceObject, KeyframesObject } from "./style-types";
+export { FontFaceObject, KeyframesObject };
+export interface NestedStyleObject {
+    [x: string]: StyleObject;
+}
+export declare type StyleObject = NestedStyleObject | Properties;
+export interface StandardEngine {
+    renderStyle(style: StyleObject): string;
+    renderKeyframes(keyframes: KeyframesObject): string;
+    renderFontFace(fontFace: FontFaceObject): string;
+}
+export declare function driver(style: StyleObject, styletron: StandardEngine): string;
+export declare function getInitialStyle(): StyleObject;
+export declare function renderDeclarativeRules(style: StyleObject, styletron: StandardEngine): StyleObject;

--- a/packages/styletron-standard/src/style-types.d.ts
+++ b/packages/styletron-standard/src/style-types.d.ts
@@ -1,0 +1,20 @@
+import { StandardProperties, VendorProperties, ObsoleteProperties, SvgProperties, AnimationNameProperty as CTAnimationNameProperty, FontFamilyProperty as CTFontFamilyProperty, FontFace as CTFontFace } from "csstype";
+export interface KeyframesPercentageObject {
+    [key: string]: Properties;
+}
+export declare type KeyframesObject = KeyframesPercentageObject & {
+    from?: Properties;
+    to?: Properties;
+};
+export declare type AnimationNameProperty = CTAnimationNameProperty | KeyframesObject;
+export declare type FontFace = CTFontFace;
+export declare type FontFamilyProperty = CTFontFamilyProperty | FontFace;
+declare type TLength = string | 0;
+export declare type Properties = {
+    animationName?: AnimationNameProperty;
+    fontFamily?: FontFamilyProperty | FontFamilyProperty[];
+    MozAnimationName?: AnimationNameProperty;
+    WebkitAnimationName?: AnimationNameProperty;
+    OAnimationName?: AnimationNameProperty;
+} & Omit<StandardProperties<TLength> & VendorProperties<TLength> & ObsoleteProperties<TLength> & SvgProperties<TLength>, 'animationName' | 'fontFamily' | 'MozAnimationName' | 'WebkitAnimationName' | 'OAnimationName'>;
+export {};

--- a/packages/styletron-standard/tsconfig.json
+++ b/packages/styletron-standard/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "jsx": "react",
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": "./packages",
+    "paths": {
+      "styletron-engine-atomic": [
+        "styletron-engine-atomic/src"
+      ],
+      "styletron-standard": [
+        "styletron-standard/src"
+      ],
+      "styletron-react": [
+        "styletron-react/src"
+      ]
+    }
+  },
+  "exclude": [
+    "packages/*/dist"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,14 +1804,14 @@
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
 
 "@types/node@*":
-  version "10.12.20"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.20.tgz#f79f959acd3422d0889bd1ead1664bd2d17cd367"
-  integrity sha512-9spv6SklidqxevvZyOUGjZVz4QRXGu2dNaLyXIFzFYZW0AGDykzPRIUFJXTlQXyfzAucddwTcGtJNim8zqSOPA==
+  version "12.7.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.4.tgz#64db61e0359eb5a8d99b55e05c729f130a678b04"
+  integrity sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==
 
 "@types/node@^9.3.0":
-  version "9.6.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.23.tgz#fc429962c1b75f32bd66214a3997f660e8434f0d"
-  integrity sha512-d2SJJpwkiPudEQ3+9ysANN2Nvz4QJKUPoe/WL5zyQzI0RaEeZWH5K5xjvUIGszTItHQpFPdH+u51f6G/LkS8Cg==
+  version "9.6.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.51.tgz#37318c930f1d1929f8a70d71f2893ac1ad0c5594"
+  integrity sha512-5lhC7QM2J3b/+epdwaNfRuG2peN4c9EX+mkd27+SqLKhJSdswHTZvc4aZLBZChi+Wo32+E1DeMZs0fSpu/uBXQ==
 
 "@types/rimraf@^0.0.28":
   version "0.0.28"
@@ -9591,6 +9591,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,10 +1813,28 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.51.tgz#37318c930f1d1929f8a70d71f2893ac1ad0c5594"
   integrity sha512-5lhC7QM2J3b/+epdwaNfRuG2peN4c9EX+mkd27+SqLKhJSdswHTZvc4aZLBZChi+Wo32+E1DeMZs0fSpu/uBXQ==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.8.23":
+  version "16.9.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.23.tgz#1a66c6d468ba11a8943ad958a8cb3e737568271c"
+  integrity sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/rimraf@^0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
   integrity sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=
+
+"@types/webpack-env@^1.13.9":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.1.tgz#c8e84705e08eed430b5e15b39c65b0944e4d1422"
+  integrity sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -3666,6 +3684,11 @@ cssnano-simple@1.0.0:
   dependencies:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
+
+csstype@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
While building a [tool for flow to typescript migration](https://github.com/zxbodya/flowts), I used styletron as one of the projects to test it. And so - now I have typescript version of styletron(https://github.com/zxbodya/styletron/tree/ts)

Type definitions in this PR are generated from that typescript version.

While doing it, I was trying to make it compatible with definitions currently in DefinitelyTyped(ensuring things like type parameters order in generics to be the same), also I did some additional corrections while using it with migrated version of baseui

For the most part(except maybe some places where flow types were not very accurate) - new type definitions are more accurate comparing to the version in DefinitelyTyped.

btw, this should also help with #337