### PR TITLE
Remove react hook from useStyletron's returned function

### DIFF
--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -152,6 +152,10 @@ export function useStyletron() {
   const debugEngine = React.useContext(DebugEngineContext);
   const hydrating = React.useContext(HydrationContext);
   checkNoopEngine(styletronEngine);
+
+  const debugClassName = React.useRef("");
+  const prevDebugClassNameDeps = React.useRef([]);
+
   return [
     function css(style: StyleObject) {
       const className = driver(style, styletronEngine);
@@ -159,16 +163,26 @@ export function useStyletron() {
         return className;
       }
       const {stack, message} = new Error("stacktrace source");
-      const debugClassName = React.useMemo(() => {
+
+      const nextDeps = [debugEngine, hydrating];
+      if (
+        prevDebugClassNameDeps[0] !== nextDeps[0] ||
+        prevDebugClassNameDeps[1] !== nextDeps[1]
+      ) {
         if (debugEngine && !hydrating) {
-          return debugEngine.debug({
+          debugClassName.current = debugEngine.debug({
             stackInfo: {stack, message},
             stackIndex: 1,
           });
         }
-        return "";
-      }, [debugEngine, hydrating]);
-      return debugClassName ? `${debugClassName} ${className}` : className;
+        prevDebugClassNameDeps.current = nextDeps;
+      }
+
+      if (debugClassName.current) {
+        return `${debugClassName.current} ${className}`;
+      }
+
+      return className;
     },
   ];
 }


### PR DESCRIPTION
Problem described in this issue: https://github.com/styletron/styletron/issues/328
tldr: the function returned from `useStyletron` contains a `React.useMemo` call, leading to unexpected [rules-of-hooks](https://reactjs.org/docs/hooks-rules.html) violations.

This diff removes the `useMemo` call and replaces it by imperatively checking if the `debugClassName` should be updated. Consumers may now conditionally call this function.