### PR TITLE
Update csstype and Flow versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-flowtype": "^4.3.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
-    "flow-bin": "^0.105.2",
+    "flow-bin": "^0.110.0",
     "lerna": "^2.11.0",
     "prettier": "^1.18.2"
   },

--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -30,7 +30,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "csstype": "frenic/csstype#16af68b",
+    "csstype": "frenic/csstype#8969c4b",
     "inline-style-prefixer": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -30,7 +30,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "csstype": "2.6.5",
+    "csstype": "frenic/csstype#16af68b",
     "inline-style-prefixer": "^5.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,10 +3662,9 @@ cssnano-simple@1.0.0:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
 
-csstype@2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
-  integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
+csstype@frenic/csstype#16af68b:
+  version "2.6.4"
+  resolved "https://codeload.github.com/frenic/csstype/tar.gz/16af68b4cf373af95e5522b7975c26ad49887ee3"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,10 +4715,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.105.2:
-  version "0.105.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.105.2.tgz#9d03d5ae3e1d011e311f309cb8786b3b3695fec2"
-  integrity sha512-VCHt0SCjFPviv/Ze/W7AgkcE0uH4TocypSFA8wR3ZH1P7BSjny4l3uhHyOjzU3Qo1i0jO4NyaU6q3Y5IaQ6xng==
+flow-bin@^0.110.0:
+  version "0.110.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.110.0.tgz#c6c140e239f662839d8f61b64b7b911f12d3306c"
+  integrity sha512-mmdEPEMoTuX+mguy/tjRlOlCtPfVdXZQeMgCAsEDVDgWMA5vwWhM2y653OcJiKX38t4gtZ2e/MNVo0qzyYeZDQ==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,9 +3662,9 @@ cssnano-simple@1.0.0:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
 
-csstype@frenic/csstype#16af68b:
+csstype@frenic/csstype#8969c4b:
   version "2.6.4"
-  resolved "https://codeload.github.com/frenic/csstype/tar.gz/16af68b4cf373af95e5522b7975c26ad49887ee3"
+  resolved "https://codeload.github.com/frenic/csstype/tar.gz/8969c4b71563df5ffd3e021cbfd5ee94db297882"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Fixes https://github.com/styletron/styletron/issues/338

https://github.com/frenic/csstype/pull/67 is landed (https://github.com/frenic/csstype/commit/8969c4b71563df5ffd3e021cbfd5ee94db297882) but currently unreleased.

Based on passing CI in https://github.com/styletron/styletron/pull/344/commits/4e1c371b3b2f2bcb10705182ef0fe4105ae2c0c3 (updating csstype without updating Flow), I believe this change should be backwards-compatible with older version of Flow (or at least v0.105.2)