### PR TITLE
Add flow test for null and undefined values

### DIFF
--- a/packages/flow-type-tests/null-and-undefined-values.js
+++ b/packages/flow-type-tests/null-and-undefined-values.js
@@ -1,0 +1,14 @@
+// @flow
+
+import * as React from "react";
+import {styled} from "styletron-react";
+
+const Foo = styled("div", {
+  // $FlowFixMe
+  zIndex: null, // null is not a valid value
+});
+
+const Bar = styled("div", {
+  // $FlowFixMe
+  zIndex: void 0, // undefined is not a valid value
+});

--- a/packages/flow-type-tests/null-and-undefined-values.js
+++ b/packages/flow-type-tests/null-and-undefined-values.js
@@ -12,3 +12,6 @@ const Bar = styled("div", {
   // $FlowFixMe
   zIndex: void 0, // undefined is not a valid value
 });
+
+<Foo />;
+<Bar />;

--- a/packages/flow-type-tests/null-values.js
+++ b/packages/flow-type-tests/null-values.js
@@ -9,8 +9,9 @@ const Foo = styled("div", {
 });
 
 const Bar = styled("div", {
-  // $FlowFixMe
-  zIndex: void 0, // undefined is not a valid value
+  // zIndex is an optional property, so undefined is allowed as a value by Flow
+  // Using undefined as a value is also convenient when optionally setting a value
+  zIndex: void 0,
 });
 
 <Foo />;


### PR DESCRIPTION
Ensure we have regression tests that explicitly define the validity of `null` and `undefined` values