### PR TITLE
Add Flow support for null values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 node_js:
   - 10
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.1
   - export PATH=$HOME/.yarn/bin:$PATH
 cache:
   yarn: true

--- a/packages/flow-type-tests/null-values.js
+++ b/packages/flow-type-tests/null-values.js
@@ -4,8 +4,9 @@ import * as React from "react";
 import {styled} from "styletron-react";
 
 const Foo = styled("div", {
-  // $FlowFixMe
-  zIndex: null, // null is not a valid value
+  // Using null values was previously supported, albeit erroneously
+  // So we should continue to support null values in Flow for the time being
+  zIndex: null,
 });
 
 const Bar = styled("div", {

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -157,8 +157,8 @@ function injectFixtureStyles(styletron) {
     zIndex: void 0, // Should be silently ignored
   });
   styletron.renderStyle({
-    // $FlowFixMe
-    opacity: null, // Should be silently ignored at runtime
+    // null values were historically supported (albeit erronesouly)
+    opacity: null, // Should be silently ignored
   });
   styletron.renderStyle({
     ":hover": {

--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -30,7 +30,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "csstype": "frenic/csstype#8969c4b",
+    "csstype": "rtsao/csstype#c4e709f",
     "inline-style-prefixer": "^5.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,9 +3662,9 @@ cssnano-simple@1.0.0:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
 
-csstype@frenic/csstype#8969c4b:
+csstype@rtsao/csstype#c4e709f:
   version "2.6.4"
-  resolved "https://codeload.github.com/frenic/csstype/tar.gz/8969c4b71563df5ffd3e021cbfd5ee94db297882"
+  resolved "https://codeload.github.com/rtsao/csstype/tar.gz/c4e709f5e047e9cacb721e437f53f0b84d6ada84"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
`null` values were historically supported (albeit erroneously) in Flow. To avoid a breaking change, this adds Flow support.

It's worth noting that this brings runtime and Flow support into alignment, as `null` values were implicitly ignored at runtime.

This is a bit of a stopgap solution, but we can make a breaking change in the future to remove support for `null` values (both statically and at runtime).