### PR TITLE
Avoid install via GitHub

### DIFF
--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -30,6 +30,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "@rtsao/csstype": "2.6.5-forked.0",
     "csstype": "rtsao/csstype#c4e709f",
     "inline-style-prefixer": "^5.1.0"
   },

--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@rtsao/csstype": "2.6.5-forked.0",
-    "csstype": "rtsao/csstype#c4e709f",
     "inline-style-prefixer": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/styletron-standard/src/style-types.js
+++ b/packages/styletron-standard/src/style-types.js
@@ -8,7 +8,7 @@ import type {
   AnimationNameProperty as CTAnimationNameProperty,
   FontFamilyProperty as CTFontFamilyProperty,
   FontFace as CTFontFace,
-} from "csstype";
+} from "@rtsao/csstype";
 
 export type KeyframesObject = {
   from?: Properties,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3667,10 +3667,6 @@ cssnano-simple@1.0.0:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
 
-csstype@rtsao/csstype#c4e709f:
-  version "2.6.4"
-  resolved "https://codeload.github.com/rtsao/csstype/tar.gz/c4e709f5e047e9cacb721e437f53f0b84d6ada84"
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,6 +1788,11 @@
     invariant "^2.2.2"
     semver "^5.3.0"
 
+"@rtsao/csstype@2.6.5-forked.0":
+  version "2.6.5-forked.0"
+  resolved "https://registry.yarnpkg.com/@rtsao/csstype/-/csstype-2.6.5-forked.0.tgz#b5b4e2a07ad83a91874ebf5fabdb73dc8c1632f6"
+  integrity sha512-0HwnY8uPWcCloTgdbbaJG3MbDUfNf6yKWZfCKxFv9yj2Sbp4mSKaIjC7Cr/5L4hMxvrrk85CU3wlAg7EtBBJ1Q==
+
 "@types/core-js@^0.9.41":
   version "0.9.46"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"


### PR DESCRIPTION
In rare instances, depending on the environment, fetching dependencies via GitHub fails. This PR replaces the dependency on the fork with an equivalent published package.

Fixes https://github.com/styletron/styletron/issues/347

