### PR TITLE
Replace usage of dataset with getAttribute

### DIFF
--- a/packages/styletron-engine-atomic/src/client/client.js
+++ b/packages/styletron-engine-atomic/src/client/client.js
@@ -185,7 +185,7 @@ class StyletronClient implements StandardEngine {
 
       for (let i = 0; i < opts.hydrate.length; i++) {
         const element = opts.hydrate[i];
-        const hydrateType = element.dataset.hydrate;
+        const hydrateType = element.getAttribute("data-hydrate");
         if (hydrateType === "font-face") {
           hydrate(this.fontFaceCache, FONT_FACE_HYDRATOR, element.textContent);
           continue;


### PR DESCRIPTION
IE 10 doesn't support `dataset`: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes#Issues

So all else being equal, using `getAttribute` seems preferable for wider compatibility.