### PR TITLE
Fix useStyletron debug mode regression

### DIFF
--- a/packages/styletron-react/src/__tests__/tests.browser.js
+++ b/packages/styletron-react/src/__tests__/tests.browser.js
@@ -583,6 +583,7 @@ test("styled debug mode (ssr)", t => {
   );
   t.end();
 });
+
 test("font-face injection", t => {
   t.plan(2);
   const fontFace = {
@@ -695,6 +696,46 @@ test("useStyletron css", t => {
     </Provider>,
   );
   t.end();
+});
+
+test("useStyletron debug mode", t => {
+  t.plan(3);
+
+  function Widget() {
+    const [css] = useStyletron();
+    const [on, setOn] = React.useState(false);
+    const className = css({color: "red"});
+    return (
+      <button onClick={() => setOn(!on)} className={className}>
+        test
+      </button>
+    );
+  }
+
+  let debugCallCount = 0;
+  const wrapper = Enzyme.mount(
+    <Provider
+      value={{
+        renderStyle: () => "bar",
+        renderKeyframes: () => "",
+        renderFontFace: () => "",
+      }}
+      debug={{
+        debug: () => {
+          debugCallCount++;
+          return `__debug-${debugCallCount}`;
+        },
+      }}
+    >
+      <Widget />
+    </Provider>,
+  );
+
+  const button = wrapper.find("button");
+  t.ok(button.hasClass("__debug-1 bar"), "adds debug class");
+  button.simulate("click");
+  t.ok(button.hasClass("__debug-1 bar"), "adds debug class");
+  t.equal(debugCallCount, 1, "debug only called on initial render");
 });
 
 test("no-op engine", t => {

--- a/packages/styletron-react/src/index.js
+++ b/packages/styletron-react/src/index.js
@@ -166,8 +166,8 @@ export function useStyletron() {
 
       const nextDeps = [debugEngine, hydrating];
       if (
-        prevDebugClassNameDeps[0] !== nextDeps[0] ||
-        prevDebugClassNameDeps[1] !== nextDeps[1]
+        prevDebugClassNameDeps.current[0] !== nextDeps[0] ||
+        prevDebugClassNameDeps.current[1] !== nextDeps[1]
       ) {
         if (debugEngine && !hydrating) {
           debugClassName.current = debugEngine.debug({


### PR DESCRIPTION
I introduced a clear mistake in the useStyletron hook which caused debug class names to be regenerated on each re-render. Corrected so that it compared against the ref's `current` value rather than the ref object itself