### PR TITLE
Fix type error in newer versions of Flow

### DIFF
--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -143,14 +143,14 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
       class: originalClassName
         ? `${className} ${originalClassName}`
         : className,
-      ...(rest : attrsT),
+      ...(rest: attrsT),
     };
     html += `<style${attrsToString(attrs)}>${sheet.css}</style>`;
   }
   return html;
 }
 
-function attrsToString(attrs : attrsT) {
+function attrsToString(attrs: attrsT) {
   let result = "";
   for (const attr in attrs) {
     const value = attrs[attr];
@@ -176,7 +176,7 @@ function stringify(styleRules, sortedCacheKeys) {
   return result;
 }
 
-function sheetify(styleRules, sortedCacheKeys) : Array<sheetT> {
+function sheetify(styleRules, sortedCacheKeys): Array<sheetT> {
   if (sortedCacheKeys.length === 0) {
     return [{css: "", attrs: {}}];
   }

--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -134,10 +134,10 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
     const sheet = sheets[i];
     const {class: originalClassName, ...rest} = sheet.attrs;
     const attrs = {
+      ...rest,
       class: originalClassName
         ? `${className} ${originalClassName}`
         : className,
-      ...rest,
     };
     html += `<style${attrsToString(attrs)}>${sheet.css}</style>`;
   }

--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -150,7 +150,7 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
   return html;
 }
 
-function attrsToString(attrs : {[string]: string}) {
+function attrsToString(attrs : attrsT) {
   let result = "";
   for (const attr in attrs) {
     const value = attrs[attr];

--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -23,9 +23,15 @@ import {
   fontFaceBlockToRule,
 } from "../css.js";
 
+export type attrsT = {
+  "data-hydrate"?: "keyframes" | "font-face",
+  media?: string,
+  class?: string,
+};
+
 export type sheetT = {|
   css: string,
-  attrs: {[string]: string},
+  attrs: attrsT,
 |};
 
 type optionsT = {
@@ -133,18 +139,20 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
   for (let i = 0; i < sheets.length; i++) {
     const sheet = sheets[i];
     const {class: originalClassName, ...rest} = sheet.attrs;
+
     const attrs = {
-      ...rest,
       class: originalClassName
         ? `${className} ${originalClassName}`
         : className,
+      ...(rest : attrsT),
     };
     html += `<style${attrsToString(attrs)}>${sheet.css}</style>`;
   }
   return html;
 }
 
-function attrsToString(attrs) {
+
+function attrsToString(attrs : {[string]: string}) {
   let result = "";
   for (const attr in attrs) {
     const value = attrs[attr];
@@ -170,7 +178,7 @@ function stringify(styleRules, sortedCacheKeys) {
   return result;
 }
 
-function sheetify(styleRules, sortedCacheKeys) {
+function sheetify(styleRules, sortedCacheKeys) : Array<sheetT> {
   if (sortedCacheKeys.length === 0) {
     return [{css: "", attrs: {}}];
   }

--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -139,7 +139,6 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
   for (let i = 0; i < sheets.length; i++) {
     const sheet = sheets[i];
     const {class: originalClassName, ...rest} = sheet.attrs;
-
     const attrs = {
       class: originalClassName
         ? `${className} ${originalClassName}`
@@ -150,7 +149,6 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
   }
   return html;
 }
-
 
 function attrsToString(attrs : {[string]: string}) {
   let result = "";


### PR DESCRIPTION
```
❯ yarn flow
yarn run v1.22.0
$ flow --max-warnings=0
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ packages/styletron-engine-atomic/src/server/server.js:140:10

Cannot determine a type for object literal [1]. rest of object pattern [2] is inexact, so it may contain class with a
type that conflicts with class's definition in object literal [1]. Can you make rest of object pattern [2] exact?

 [2] 135│     const {class: originalClassName, ...rest} = sheet.attrs;
 [1] 136│     const attrs = {
     137│       class: originalClassName
     138│         ? `${className} ${originalClassName}`
     139│         : className,
     140│       ...rest,
     141│     };
     142│     html += `<style${attrsToString(attrs)}>${sheet.css}</style>`;
     143│   }
```

Fixes the above error in newer versions of Flow