### PR TITLE
Do not create class when font-family is undefined

### DIFF
--- a/packages/styletron-standard/src/__tests__/core.node.js
+++ b/packages/styletron-standard/src/__tests__/core.node.js
@@ -1,11 +1,12 @@
 // @flow
 import test from "tape";
-import {Server} from "styletron-engine-atomic";
+import {Server as ServerMonolithic} from "styletron-engine-monolithic";
+import {Server as ServerAtomic} from "styletron-engine-atomic";
 import {driver} from "../index";
 
-test("driver", t => {
+test("driver atomic", t => {
   let cssString;
-  const instance = new Server();
+  const instance = new ServerAtomic();
   const styleObject = {
     color: "red",
   };
@@ -31,5 +32,50 @@ test("driver", t => {
     cssString,
     "injects font fallbacks - declared",
   );
+  t.end();
+});
+
+test("driver monolithic", t => {
+  let cssString;
+  const instance = new ServerMonolithic();
+  const styleObject = {
+    color: "red",
+  };
+  driver(styleObject, instance);
+  cssString = ".css-jZABor{color:red;}";
+  t.strictEqual(instance.getCss(), cssString, "injects basic style");
+  const fontFallback = {
+    fontFamily: ["Arial", "sans-serif"],
+  };
+  driver(fontFallback, instance);
+  cssString = `${cssString}.css-hAHJYW{font-family:Arial,sans-serif;}`;
+  t.strictEqual(instance.getCss(), cssString, "injects font fallbacks - basic");
+  const fontFace = {
+    src: "url(some-awesome-font.ttf)",
+  };
+  const declaredFontFaceFallback = {
+    fontFamily: [fontFace, "cursive"],
+  };
+  driver(declaredFontFaceFallback, instance);
+  cssString = `${cssString}@font-face{font-family:font-jllknz;src:url(some-awesome-font.ttf)}.css-cwIyhY{font-family:font-jllknz,cursive;}`;
+  t.strictEqual(
+    instance.getCss(),
+    cssString,
+    "injects font fallbacks - declared",
+  );
+  t.end();
+});
+
+test("font-family undefined consistency between engines", t => {
+  const atomic = new ServerAtomic();
+  const monolithic = new ServerMonolithic();
+
+  // eslint-disable-next-line no-undefined
+  driver({fontFamily: undefined}, atomic);
+  t.strictEqual(atomic.getCss(), "", "atomic font-family undefined");
+
+  // eslint-disable-next-line no-undefined
+  driver({fontFamily: undefined}, monolithic);
+  t.strictEqual(monolithic.getCss(), "", "monolithic font-family undefined");
   t.end();
 });

--- a/packages/styletron-standard/src/index.js
+++ b/packages/styletron-standard/src/index.js
@@ -59,6 +59,8 @@ export function renderDeclarativeRules(
         }
         style.fontFamily = result.slice(0, -1);
         continue;
+      } else if (val === void 0) {
+        continue;
       } else {
         style.fontFamily = styletron.renderFontFace((val: any));
         continue;


### PR DESCRIPTION
I initially found this as an inconsistency between atomic and monolithic engines. Given this css object `{fontFamily: undefined}` monolithic engine would crash (failing to stringify undefined) and atomic engine would output an erroneous css string (` '@font-face{font-family:ae;}.ae{font-family:ae}’`). This change makes it so that in both cases, the css string is empty. To view the previous behavior, revert the change in styletron-standard code and run tests.