### PR TITLE
Relax react peer dependency range

### DIFF
--- a/packages/styletron-react/package.json
+++ b/packages/styletron-react/package.json
@@ -34,7 +34,7 @@
     "styletron-standard": "^3.0.5"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.0.0-beta.56",


### PR DESCRIPTION
The only slightly useful part of this range is to ensure that hooks exists (i.e. v16.8+). IMHO, using strict peer dependency ranges to guard against incompatible future versions is usually counterproductive, the only real purpose for peer deps is telling the package manager a singleton is required. Minimum versions can be helpful, but I think upper bounds almost always provide zero benefit. After all, the actual react version comes from the consuming application, not our package.