### PR TITLE
add support for styles rendering and streaming

### DIFF
--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -130,7 +130,11 @@ class StyletronServer implements StandardEngine {
             },
           ]
         : []),
-      ...sheetify(this.styleRules, this.styleCache.getSortedCacheKeys()),
+      ...sheetify(
+        this.styleRules,
+        this.styleCache.getSortedCacheKeys(),
+        this.streamingMode,
+      ),
     ];
 
     // Clear streamed styles
@@ -257,7 +261,7 @@ function stringify(styleRules, sortedCacheKeys) {
   return result;
 }
 
-function sheetify(styleRules, sortedCacheKeys): Array<sheetT> {
+function sheetify(styleRules, sortedCacheKeys, streamingMode): Array<sheetT> {
   if (sortedCacheKeys.length === 0) {
     return [{css: "", attrs: {}}];
   }
@@ -265,8 +269,14 @@ function sheetify(styleRules, sortedCacheKeys): Array<sheetT> {
   sortedCacheKeys.forEach(cacheKey => {
     // omit media (cacheKey) attribute if empty
     const attrs = cacheKey === "" ? {} : {media: cacheKey};
+    let insertBeforeMedia =
+      streamingMode && styleRules[cacheKey].insertBeforeMedia
+        ? styleRules[cacheKey].insertBeforeMedia
+        : null;
+    if (streamingMode)
+      insertBeforeMedia = styleRules[cacheKey].insertBeforeMedia || null;
     sheets.push({
-      insertBeforeMedia: styleRules[cacheKey].insertBeforeMedia,
+      ...(insertBeforeMedia && {insertBeforeMedia}),
       css: styleRules[cacheKey].rules,
       attrs,
     });

--- a/packages/styletron-engine-atomic/src/server/server.js
+++ b/packages/styletron-engine-atomic/src/server/server.js
@@ -1,4 +1,5 @@
 // @flow
+import {Readable, Transform} from "stream";
 
 import SequentialIDGenerator from "../sequential-id-generator.js";
 
@@ -30,32 +31,44 @@ export type attrsT = {
 };
 
 export type sheetT = {|
+  insertBeforeMedia?: string,
   css: string,
   attrs: attrsT,
 |};
 
 type optionsT = {
   prefix?: string,
+  streamingMode?: boolean,
 };
 
 class StyletronServer implements StandardEngine {
   styleCache: MultiCache<{pseudo: string, block: string}>;
   keyframesCache: Cache<KeyframesObject>;
   fontFaceCache: Cache<FontFaceObject>;
-  styleRules: {[string]: string};
+  styleRules: {
+    [string]: {
+      insertBeforeMedia?: string,
+      rules: string,
+    },
+  };
   keyframesRules: string;
   fontFaceRules: string;
+  streamingMode: boolean;
 
   constructor(opts?: optionsT = {}) {
-    this.styleRules = {"": ""};
+    this.streamingMode = opts.streamingMode || false;
+    this.styleRules = {"": {rules: ""}};
     this.styleCache = new MultiCache(
       new SequentialIDGenerator(opts.prefix),
-      media => {
-        this.styleRules[media] = "";
+      (media, _cache, insertBeforeMedia) => {
+        this.styleRules[media] = {
+          ...(insertBeforeMedia && {insertBeforeMedia}),
+          rules: "",
+        };
       },
       (cache, id, value) => {
         const {pseudo, block} = value;
-        this.styleRules[cache.key] += styleBlockToRule(
+        this.styleRules[cache.key].rules += styleBlockToRule(
           atomicSelector(id, pseudo),
           block,
         );
@@ -100,7 +113,7 @@ class StyletronServer implements StandardEngine {
   }
 
   getStylesheets(): Array<sheetT> {
-    return [
+    const sheets = [
       ...(this.keyframesRules.length
         ? [
             {
@@ -119,10 +132,68 @@ class StyletronServer implements StandardEngine {
         : []),
       ...sheetify(this.styleRules, this.styleCache.getSortedCacheKeys()),
     ];
+
+    // Clear streamed styles
+    if (this.streamingMode) {
+      this.keyframesRules = "";
+      this.fontFaceRules = "";
+      for (const prop in this.styleRules) {
+        this.styleRules[prop].rules = "";
+      }
+    }
+
+    return sheets;
   }
 
   getStylesheetsHtml(className?: string = "_styletron_hydrate_") {
-    return generateHtmlString(this.getStylesheets(), className);
+    return generateHtmlString(
+      this.getStylesheets(),
+      className,
+      this.streamingMode,
+    );
+  }
+
+  // Copied and adapted from: https://github.com/styled-components/styled-components/blob/28b4c28f1e/packages/styled-components/src/models/ServerStyleSheet.js#L78
+  getStylesheetsStream(htmlStream: Readable) {
+    if (!this.streamingMode)
+      throw new Error(
+        "getStylesheetsStream() requires streamingMode to be set to true for Styletron server",
+      );
+
+    const readableStream: Readable = htmlStream;
+    const CLOSING_TAG_R = /^\s*<\/[a-z]/i;
+
+    const instance = this;
+
+    const transformer = new Transform({
+      transform: function appendStyleChunks(chunk, /* encoding */ _, callback) {
+        // Get the chunk and retrieve the sheet's CSS as an HTML chunk,
+        // then reset its rules so we get only new ones for the next chunk
+        const htmlChunk = chunk.toString();
+        const cssScriptChunk = instance.getStylesheetsHtml();
+
+        // prepend style html to chunk, unless the start of the chunk is a
+        // closing tag in which case append right after that
+        if (CLOSING_TAG_R.test(htmlChunk)) {
+          const endOfClosingTag = htmlChunk.indexOf(">") + 1;
+          const before = htmlChunk.slice(0, endOfClosingTag);
+          const after = htmlChunk.slice(endOfClosingTag);
+
+          this.push(before + cssScriptChunk + after);
+        } else {
+          this.push(cssScriptChunk + htmlChunk);
+        }
+
+        callback();
+      },
+    });
+
+    readableStream.on("error", err => {
+      // forward the error to the transform stream
+      transformer.emit("error", err);
+    });
+
+    return readableStream.pipe(transformer);
   }
 
   getCss() {
@@ -134,7 +205,11 @@ class StyletronServer implements StandardEngine {
   }
 }
 
-export function generateHtmlString(sheets: Array<sheetT>, className: string) {
+export function generateHtmlString(
+  sheets: Array<sheetT>,
+  className: string,
+  streamingMode: boolean = false,
+) {
   let html = "";
   for (let i = 0; i < sheets.length; i++) {
     const sheet = sheets[i];
@@ -145,8 +220,14 @@ export function generateHtmlString(sheets: Array<sheetT>, className: string) {
         : className,
       ...(rest: attrsT),
     };
-    html += `<style${attrsToString(attrs)}>${sheet.css}</style>`;
+
+    if (!streamingMode) {
+      html += `<style${attrsToString(attrs)}>${sheet.css}</style>`;
+    } else {
+      html += generateScript(sheet, className, attrs);
+    }
   }
+
   return html;
 }
 
@@ -166,7 +247,7 @@ function attrsToString(attrs: attrsT) {
 function stringify(styleRules, sortedCacheKeys) {
   let result = "";
   sortedCacheKeys.forEach(cacheKey => {
-    const rules = styleRules[cacheKey];
+    const rules = styleRules[cacheKey].rules;
     if (cacheKey !== "") {
       result += `@media ${cacheKey}{${rules}}`;
     } else {
@@ -184,9 +265,56 @@ function sheetify(styleRules, sortedCacheKeys): Array<sheetT> {
   sortedCacheKeys.forEach(cacheKey => {
     // omit media (cacheKey) attribute if empty
     const attrs = cacheKey === "" ? {} : {media: cacheKey};
-    sheets.push({css: styleRules[cacheKey], attrs});
+    sheets.push({
+      insertBeforeMedia: styleRules[cacheKey].insertBeforeMedia,
+      css: styleRules[cacheKey].rules,
+      attrs,
+    });
   });
   return sheets;
+}
+
+function generateScript(sheet: sheetT, className: string, attrs: attrsT) {
+  if (!sheet.css.length) return "";
+
+  const content = [];
+  content.push(`
+  <script>
+  (function () {
+  `);
+
+  const selector = attrs.media
+    ? `style.${className}[media='${attrs.media}']`
+    : `style.${className}:not([media])`;
+
+  content.push(`
+    let styleElement = document.head.querySelector("${selector}");
+    if (!styleElement) {
+      styleElement = document.createElement("style");`);
+
+  for (const attr in attrs) {
+    content.push(`
+      styleElement.setAttribute("${attr}", "${attrs[attr]}");`);
+  }
+
+  if (sheet.insertBeforeMedia) {
+    content.push(`
+      const predecessor = document.querySelectorAll('[media="${sheet.insertBeforeMedia}"]')[0]
+      document.head.insertBefore(styleElement, predecessor);`);
+  } else {
+    content.push(`
+      document.head.append(styleElement);`);
+  }
+
+  content.push(`
+    }
+    styleElement.innerHTML = styleElement.innerHTML + " ${sheet.css}"
+    document.currentScript.remove();
+  }());
+  </script>
+  `);
+
+  return content.join("");
 }
 
 export default StyletronServer;


### PR DESCRIPTION
This closes [styletron/styletron/#334](https://github.com/styletron/styletron/issues/334)

#### Implementation details:
- Exposes a new method `getStylesheetsStream` that takes as an input a readable html stream and adds the newly rendered styles to it
- Clears older styles after each render
- Generates script tags that inject style tags in the document head
- New rendered styles are injected inside the appropriate media scoped style tag
- Style tags are ordered inside the head tag to support a mobile first approach

Looking forward to your feedback before adding tests/docs!
Thanks

#### Checklist
- [x] run tests
- [ ] tests updated
- [ ] documentation is changed or added