### PR TITLE
Handle nested pseudo selectors in monolithic engine

### DIFF
--- a/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
+++ b/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
@@ -104,6 +104,34 @@ test("rendering", t => {
     ],
     "media queries are mobile first sorted",
   );
+
+  instance.renderStyle({
+    ":hover": {
+      color: "orange",
+      ":after": {
+        content: '"abc"',
+      },
+    },
+  });
+  t.deepEqual(
+    sheetsToRules(document.styleSheets),
+    [
+      {
+        media: "",
+        rules: [
+          ".ae { color: purple; }",
+          ".ag { user-select: none; }",
+          ".ah { display: flex; }",
+          ".aj:hover { color: orange; }",
+          '.ak:hover::after { content: "abc"; }',
+        ],
+      },
+      {media: "(min-width: 600px)", rules: [".ai { color: red; }"]},
+      {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+    ],
+    "renders nested pseudo-selectors",
+  );
+
   instance.container.remove();
   t.end();
 });

--- a/packages/styletron-engine-monolithic/src/client/__tests__/client.browser.js
+++ b/packages/styletron-engine-monolithic/src/client/__tests__/client.browser.js
@@ -40,6 +40,7 @@ test("rendering", t => {
   const container = document.createElement("div");
   document.body && document.body.appendChild(container);
   const instance = new StyletronClient({container});
+
   t.equal(
     instance.renderStyle({color: "purple"}),
     "css-hZftBk",
@@ -48,6 +49,7 @@ test("rendering", t => {
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {media: "", rules: [".css-hZftBk { color: purple; }"]},
   ]);
+
   t.equal(
     instance.renderStyle({
       "@media (min-width: 800px)": {color: "purple"},
@@ -67,6 +69,7 @@ test("rendering", t => {
       ],
     },
   ]);
+
   instance.renderStyle({
     userSelect: "none",
   });
@@ -80,6 +83,7 @@ test("rendering", t => {
     },
     {media: "", rules: [".css-eaGfYw { user-select: none; }"]},
   ]);
+
   instance.renderStyle({
     display: "flex",
   });
@@ -94,6 +98,7 @@ test("rendering", t => {
     {media: "", rules: [".css-eaGfYw { user-select: none; }"]},
     {media: "", rules: [".css-haOmqK { display: flex; }"]},
   ]);
+
   instance.renderStyle({
     "@media (min-width: 600px)": {
       color: "red",
@@ -120,6 +125,7 @@ test("rendering", t => {
     ],
     "order of rules is preserved",
   );
+
   instance.container.remove();
   t.end();
 });
@@ -205,26 +211,82 @@ test("StyletronClient deeply nested rules", t => {
   const container = document.createElement("div");
   document.body && document.body.appendChild(container);
   const instance = new StyletronClient({container});
+
   t.equal(
     instance.renderStyle({
       "@supports (flex-wrap: wrap)": {
         "@media (min-width: 50em)": {
+          color: "green",
           ":hover": {
-            background: "blue",
+            color: "blue",
           },
         },
       },
     }),
-    "css-gPyDTX",
+    "css-jrXsOI",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {
       media: "",
       rules: [
-        "@supports (flex-wrap: wrap) {\n  @media (min-width: 50em) {\n  .css-gPyDTX:hover { background: blue; }\n}\n}",
+        "@supports (flex-wrap: wrap) {\n  @media (min-width: 50em) {\n  .css-jrXsOI { color: green; }\n  .css-jrXsOI:hover { color: blue; }\n}\n}",
       ],
     },
   ]);
+
+  instance.renderStyle({
+    ":hover": {
+      color: "blue",
+      "::after": {
+        content: '"abc"',
+      },
+    },
+  });
+  t.deepEqual(sheetsToRules(document.styleSheets), [
+    {
+      media: "",
+      rules: [
+        "@supports (flex-wrap: wrap) {\n  @media (min-width: 50em) {\n  .css-jrXsOI { color: green; }\n  .css-jrXsOI:hover { color: blue; }\n}\n}",
+      ],
+    },
+    {
+      media: "",
+      rules: [
+        ".css-hFfBmH:hover { color: blue; }",
+        '.css-hFfBmH:hover::after { content: "abc"; }',
+      ],
+    },
+  ]);
+
+  instance.container.remove();
+  t.end();
+});
+
+test("reference another class name", t => {
+  const container = document.createElement("div");
+  document.body && document.body.appendChild(container);
+  const instance = new StyletronClient({container});
+
+  t.equal(
+    instance.renderStyle({
+      color: "blue",
+    }),
+    "css-yrgMo",
+  );
+  t.deepEqual(sheetsToRules(document.styleSheets), [
+    {media: "", rules: [".css-yrgMo { color: blue; }"]},
+  ]);
+
+  instance.renderStyle({
+    ".css-yrgMo:hover": {
+      color: "green",
+    },
+  });
+  t.deepEqual(sheetsToRules(document.styleSheets), [
+    {media: "", rules: [".css-yrgMo { color: blue; }"]},
+    {media: "", rules: [".css-yrgMo:hover { color: green; }"]},
+  ]);
+
   instance.container.remove();
   t.end();
 });

--- a/packages/styletron-engine-monolithic/src/inject-style-prefixed.js
+++ b/packages/styletron-engine-monolithic/src/inject-style-prefixed.js
@@ -4,80 +4,87 @@ declare var __DEV__: boolean;
 
 import hyphenate from "./hyphenate-style-name.js";
 import {validateNoMixedHand} from "./validate-no-mixed-hand.js";
-import {prefix} from "inline-style-prefixer";
+import {prefix as prefixRule} from "inline-style-prefixer";
 
 import type {StyleObject} from "styletron-standard";
 
 export default function injectStylePrefixed(
   styles: StyleObject,
-  className: string,
-  globalPrefix: string,
+  selector: string,
+  prefix: string,
   strict: boolean,
 ) {
-  const outputRules = [];
-  let plainBlock = "";
-  for (const originalKey in styles) {
-    const originalVal = styles[originalKey];
-    if (originalVal === void 0 || originalVal === null) {
+  let rules = "";
+  let classes = [];
+
+  for (const key in styles) {
+    const value = styles[key];
+
+    if (value === void 0 || value === null) {
       continue;
     }
-    if (typeof originalVal !== "object") {
-      // Non-null and non-undefined primitive value
+
+    if (typeof value !== "object") {
       if (__DEV__) {
-        validateValueType(originalVal, originalKey);
+        if (
+          value === null ||
+          Array.isArray(value) ||
+          (typeof value !== "number" && typeof value !== "string")
+        ) {
+          throw new Error(
+            `Unsupported style value: ${JSON.stringify(
+              value,
+            )} used in property ${JSON.stringify(key)}`,
+          );
+        }
       }
-      const propValPair = `${hyphenate(
-        originalKey,
-      )}:${((originalVal: any): string)}`;
-      const prefixed = prefix({[originalKey]: originalVal});
+
+      const rule = hyphenate(key) + ":" + value;
+      const prefixed = prefixRule({[key]: value});
       for (const prefixedKey in prefixed) {
         const prefixedVal = prefixed[prefixedKey];
-        const prefixedValType = typeof prefixedVal;
-        if (prefixedValType === "string" || prefixedValType === "number") {
-          const prefixedPair = `${hyphenate(prefixedKey)}:${prefixedVal}`;
-          if (prefixedPair !== propValPair) {
-            plainBlock += `${prefixedPair};`;
+        if (
+          typeof prefixedVal === "string" ||
+          typeof prefixedVal === "number"
+        ) {
+          const prefixedRule = hyphenate(prefixedKey) + ":" + prefixedVal;
+          if (prefixedRule !== rule) {
+            rules += prefixedRule + ";";
           }
         } else if (Array.isArray(prefixedVal)) {
           const hyphenated = hyphenate(prefixedKey);
           for (let i = 0; i < prefixedVal.length; i++) {
-            const prefixedPair = `${hyphenated}:${prefixedVal[i]}`;
-            if (prefixedPair !== propValPair) {
-              plainBlock += `${prefixedPair};`;
+            const prefixedRule = hyphenated + ":" + prefixedVal[i];
+            if (prefixedRule !== rule) {
+              rules += prefixedRule + ";";
             }
           }
         }
       }
-      plainBlock += `${propValPair};`;
-    } else if (originalKey[0] === ":") {
-      outputRules.push(
-        `.${globalPrefix}css-${className}${originalKey}{${injectStylePrefixed(
-          originalVal,
-          "",
-          globalPrefix,
-          strict,
-        ).join("")}}`,
-      );
-    } else if (originalKey[0] === "@") {
-      outputRules.push(
-        `${originalKey}{${injectStylePrefixed(
-          originalVal,
-          className,
-          globalPrefix,
-          strict,
-        ).join("")}}`,
-      );
-    } else {
-      outputRules.push(
-        `${originalKey}{${injectStylePrefixed(
-          originalVal,
-          "",
-          globalPrefix,
-          strict,
-        ).join("")}}`,
-      );
+      rules += rule + ";";
+      continue;
     }
+
+    if (key[0] === ":") {
+      classes = [
+        ...classes,
+        ...injectStylePrefixed(value, selector + key, prefix, strict),
+      ];
+      continue;
+    }
+
+    if (key[0] === "@") {
+      const nestedRules = injectStylePrefixed(value, selector, prefix, strict);
+      classes = [...classes, key + "{" + nestedRules.join("") + "}"];
+      continue;
+    }
+
+    classes = [
+      ...classes,
+      key + "{" + injectStylePrefixed(value, "", prefix, strict).join("") + "}",
+    ];
   }
+
   // strict mode checks for mixed long/shorthands to keep compatibility with atomic engine
   if (strict && __DEV__) {
     const conflicts = validateNoMixedHand(styles);
@@ -87,31 +94,21 @@ export default function injectStylePrefixed(
         const long = JSON.stringify({[longhand.property]: longhand.value});
         // eslint-disable-next-line no-console
         console.warn(
-          `Styles \`${short}\` and \`${long}\` in object yielding class "${className}" may result in unexpected behavior. Mixing shorthand and longhand properties within the same style object is unsupported with atomic rendering.`,
+          `Styles \`${short}\` and \`${long}\` in object yielding class "${selector}" may result in unexpected behavior. Mixing shorthand and longhand properties within the same style object is unsupported with atomic rendering.`,
         );
       });
     }
   }
-  // we are inside of a pseudo-selector
-  if (!className) {
-    return [plainBlock];
-  }
-  if (!plainBlock) {
-    return outputRules;
-  }
-  return [`.${globalPrefix}css-${className}{${plainBlock}}`, ...outputRules];
-}
 
-function validateValueType(value, key) {
-  if (
-    value === null ||
-    Array.isArray(value) ||
-    (typeof value !== "number" && typeof value !== "string")
-  ) {
-    throw new Error(
-      `Unsupported style value: ${JSON.stringify(
-        value,
-      )} used in property ${JSON.stringify(key)}`,
-    );
+  // used to handle 'exact' selectors like 'div' or referencing another class name like '.css-abc123:hover'
+  // selector is applied in the parent recursive function call.
+  if (!selector) {
+    return [rules];
   }
+
+  const result = [];
+  if (rules) {
+    result.push(`.${prefix}css-${selector}{${rules}}`);
+  }
+  return [...result, ...classes];
 }


### PR DESCRIPTION
Given the style below with nested pseudo selectors:

```
color: "orange",
":hover": {
  color: "purple",
  ":focus": {
    color: "cyan"
  }
}
```

[atomic engine](https://codesandbox.io/s/atomic-engine-nested-selectors-sofjg?file=/src/example.js) currently produces the expected combined pseudo selectors:
`.ag:hover:focus {color: cyan;} .af:hover {color: purple;} .ae {color: orange;}`

[monolithic engine](https://codesandbox.io/s/monolithic-engine-nested-selectors-oigvy?file=/src/example.js) currently leaves out the class with two pseudo selectors:
`.css-jlQCrN {color:orange;} .css-jlQCrN:hover {color:purple;}`

This PR rewrites a decent amount of the monolithic engine `injectStylePrefixed` function to handle this case and adds additional tests to validate the feature. After this change monolithic engine should correctly produce:
`.css-jlQCrN {color:orange;} .css-jlQCrN:hover {color:purple;} .css-jlQCrN:hover:focus {color:cyan;}`