### PR TITLE
Fixed API Documentation URL in Styletron React

### DIFF
--- a/packages/styletron-react/README.md
+++ b/packages/styletron-react/README.md
@@ -12,7 +12,7 @@ yarn add styletron-react
 
 ## [Documentation](https://www.styletron.org/react/)
 
-## [API](https://www.styletron.org/api/#styletron-react)
+## [API](https://www.styletron.org/api-reference#styletron-react)
 
 [deps-badge]: https://david-dm.org/rtsao/styletron-react.svg
 [deps-href]: https://david-dm.org/rtsao/styletron-react


### PR DESCRIPTION
API Link directed to an invalid link. Fixed to go to correct location.