### PR TITLE
Added speedy option when initialising monolithic client

### DIFF
--- a/packages/styletron-engine-monolithic/src/client/client.js
+++ b/packages/styletron-engine-monolithic/src/client/client.js
@@ -33,6 +33,7 @@ type optionsT = {
   container?: Element,
   prefix?: string,
   strict?: boolean,
+  speedy?: boolean,
 };
 
 type cacheT = {
@@ -88,7 +89,10 @@ class StyletronClient implements StandardEngine {
       this.container = document.head;
     }
 
-    this.styleSheet = new StyleSheet({container: this.container});
+    this.styleSheet = new StyleSheet({
+      container: this.container,
+      speedy: this.opts.speedy,
+    });
   }
 
   renderStyle(styles: StyleObject): string {


### PR DESCRIPTION
I need to be able to disable the speedy insertion of styles using CSSOM when initialising the monolithic engine prior to passing it to the `styletron-react` provider. This is so that I can ensure that style tags get added to the DOM when prerendering my app.

This PR simply adds the `speedy` option to the monolithic engine options and passes it in when initialising a new `StyleSheet` which already has the `speedy` option.

Please see https://emotion.sh/docs/ssr#puppeteer for context as to why I would like this option.