### PR TITLE
Sequential id can now generate from a to ac

### DIFF
--- a/packages/styletron-engine-atomic/src/__tests__/test.node.js
+++ b/packages/styletron-engine-atomic/src/__tests__/test.node.js
@@ -6,6 +6,8 @@ import {validateNoMixedHand} from "../validate-no-mixed-hand.js";
 
 import sortMq from "../sort-css-media-queries.js";
 
+import SequentialIDGenerator from "../sequential-id-generator.js";
+
 test("validateNoMixedHand", t => {
   t.deepEqual(
     validateNoMixedHand({
@@ -144,5 +146,17 @@ test("mixed", t => {
     "print and (orientation: portrait)",
   ];
   t.deepEqual(receivedOrder.sort(sortMq), expectedOrder);
+  t.end();
+});
+
+test("SequentialIDGenerator no ad", t => {
+  const genertedIds: string[] = [];
+  const sequentialIDGenerator = new SequentialIDGenerator();
+  for (let i = 0; i < 500; i++) {
+    genertedIds.push(sequentialIDGenerator.next());
+  }
+  t.deepEqual(genertedIds.length, 500);
+  t.deepEqual(new Set(genertedIds).size, 500);
+  t.deepEqual(genertedIds.includes("ad"), false);
   t.end();
 });

--- a/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
+++ b/packages/styletron-engine-atomic/src/client/__tests__/client.browser.js
@@ -27,7 +27,7 @@ test("automatic stylesheet insertion", t => {
   t.equal(document.styleSheets.length, 0, "sheet not yet instantiated");
   t.equal(
     instance.renderStyle({color: "purple"}),
-    "ae",
+    "a",
     "new unique class returned",
   );
   t.equal(document.styleSheets.length, 1, "sheet added");
@@ -42,22 +42,22 @@ test("rendering", t => {
   const instance = new StyletronClient({container});
   t.equal(
     instance.renderStyle({color: "purple"}),
-    "ae",
+    "a",
     "new unique class returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
-    {media: "", rules: [".ae { color: purple; }"]},
+    {media: "", rules: [".a { color: purple; }"]},
   ]);
   t.equal(
     instance.renderStyle({
       "@media (min-width: 800px)": {color: "purple"},
     }),
-    "af",
+    "b",
     "new unique class returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
-    {media: "", rules: [".ae { color: purple; }"]},
-    {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+    {media: "", rules: [".a { color: purple; }"]},
+    {media: "(min-width: 800px)", rules: [".b { color: purple; }"]},
   ]);
   instance.renderStyle({
     userSelect: "none",
@@ -65,9 +65,9 @@ test("rendering", t => {
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {
       media: "",
-      rules: [".ae { color: purple; }", ".ag { user-select: none; }"],
+      rules: [".a { color: purple; }", ".c { user-select: none; }"],
     },
-    {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+    {media: "(min-width: 800px)", rules: [".b { color: purple; }"]},
   ]);
   instance.renderStyle({
     display: "flex",
@@ -76,12 +76,12 @@ test("rendering", t => {
     {
       media: "",
       rules: [
-        ".ae { color: purple; }",
-        ".ag { user-select: none; }",
-        ".ah { display: flex; }",
+        ".a { color: purple; }",
+        ".c { user-select: none; }",
+        ".d { display: flex; }",
       ],
     },
-    {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+    {media: "(min-width: 800px)", rules: [".b { color: purple; }"]},
   ]);
   instance.renderStyle({
     "@media (min-width: 600px)": {
@@ -94,13 +94,13 @@ test("rendering", t => {
       {
         media: "",
         rules: [
-          ".ae { color: purple; }",
-          ".ag { user-select: none; }",
-          ".ah { display: flex; }",
+          ".a { color: purple; }",
+          ".c { user-select: none; }",
+          ".d { display: flex; }",
         ],
       },
-      {media: "(min-width: 600px)", rules: [".ai { color: red; }"]},
-      {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+      {media: "(min-width: 600px)", rules: [".e { color: red; }"]},
+      {media: "(min-width: 800px)", rules: [".b { color: purple; }"]},
     ],
     "media queries are mobile first sorted",
   );
@@ -119,15 +119,15 @@ test("rendering", t => {
       {
         media: "",
         rules: [
-          ".ae { color: purple; }",
-          ".ag { user-select: none; }",
-          ".ah { display: flex; }",
-          ".aj:hover { color: orange; }",
-          '.ak:hover::after { content: "abc"; }',
+          ".a { color: purple; }",
+          ".c { user-select: none; }",
+          ".d { display: flex; }",
+          ".f:hover { color: orange; }",
+          '.g:hover::after { content: "abc"; }',
         ],
       },
-      {media: "(min-width: 600px)", rules: [".ai { color: red; }"]},
-      {media: "(min-width: 800px)", rules: [".af { color: purple; }"]},
+      {media: "(min-width: 600px)", rules: [".e { color: red; }"]},
+      {media: "(min-width: 800px)", rules: [".b { color: purple; }"]},
     ],
     "renders nested pseudo-selectors",
   );
@@ -142,26 +142,26 @@ test("prefix", t => {
   const instance = new StyletronClient({container, prefix: "foo_"});
   t.equal(
     instance.renderStyle({color: "purple"}),
-    "foo_ae",
+    "foo_a",
     "new unique class returned",
   );
   t.equal(
     instance.renderFontFace({src: "url(blah)"}),
-    "foo_ae",
+    "foo_a",
     "new unique font family returned",
   );
   t.equal(
     instance.renderKeyframes({from: {color: "red"}, to: {color: "blue"}}),
-    "foo_ae",
+    "foo_a",
     "new unique animation name returned",
   );
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {
       media: "",
       rules: [
-        ".foo_ae { color: purple; }",
-        `@font-face { font-family: foo_ae; src: url("blah"); }`,
-        "@keyframes foo_ae { \n  0% { color: red; }\n  100% { color: blue; }\n}",
+        ".foo_a { color: purple; }",
+        `@font-face { font-family: foo_a; src: url("blah"); }`,
+        "@keyframes foo_a { \n  0% { color: red; }\n  100% { color: blue; }\n}",
       ],
     },
   ]);
@@ -258,7 +258,7 @@ test("sort client media queries", t => {
 
   t.deepEqual(sheetsToRules(document.styleSheets), [
     {media: "", rules: []},
-    {media: "(min-width: 700px)", rules: [".ae { color: pink; }"]},
+    {media: "(min-width: 700px)", rules: [".a { color: pink; }"]},
   ]);
 
   cleanup();
@@ -297,27 +297,27 @@ test("sort a new media query after hydration", t => {
     {
       media: "",
       rules: [
-        "@keyframes ae { \n  0% { color: red; }\n  100% { color: blue; }\n}",
+        "@keyframes a { \n  0% { color: red; }\n  100% { color: blue; }\n}",
       ],
     },
-    {media: "", rules: ['@font-face { font-family: ae; src: url("blah"); }']},
+    {media: "", rules: ['@font-face { font-family: a; src: url("blah"); }']},
     {
       media: "",
       rules: [
-        ".ae { color: red; }",
-        ".af { color: green; }",
-        ".aj:hover { display: none; }",
-        ".ak { user-select: none; }",
-        ".al { display: flex; }",
+        ".a { color: red; }",
+        ".b { color: green; }",
+        ".f:hover { display: none; }",
+        ".g { user-select: none; }",
+        ".h { display: flex; }",
       ],
     },
-    {media: "(min-width: 600px)", rules: [".ah { color: red; }"]},
-    {media: "(min-width: 700px)", rules: [".am { color: pink; }"]},
+    {media: "(min-width: 600px)", rules: [".d { color: red; }"]},
+    {media: "(min-width: 700px)", rules: [".i { color: pink; }"]},
     {
       media: "(min-width: 800px)",
-      rules: [".ag { color: green; }", ".ai:hover { color: green; }"],
+      rules: [".c { color: green; }", ".e:hover { color: green; }"],
     },
-    {media: "(min-width: 1000px)", rules: [".an { color: black; }"]},
+    {media: "(min-width: 1000px)", rules: [".j { color: black; }"]},
   ]);
 
   cleanup();

--- a/packages/styletron-engine-atomic/src/sequential-id-generator.js
+++ b/packages/styletron-engine-atomic/src/sequential-id-generator.js
@@ -8,12 +8,12 @@ export default class SequentialIDGenerator {
   power: number;
 
   constructor(prefix: string = "") {
-    // ensure start with "ae" so "ad" is never produced
     this.prefix = prefix;
     this.count = 0;
-    this.offset = 374;
-    this.msb = 1295;
-    this.power = 2;
+    // ensure we start with a, not 0
+    this.offset = 10;
+    this.msb = 35;
+    this.power = 1;
   }
 
   next() {
@@ -23,6 +23,11 @@ export default class SequentialIDGenerator {
 
   increment() {
     const id = this.count + this.offset;
+    if (id === 373) {
+      // let us skip "ad"
+      this.count++;
+      return this.increment();
+    }
     if (id === this.msb) {
       this.offset += (this.msb + 1) * 9;
       this.msb = Math.pow(36, ++this.power) - 1;

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -9,17 +9,17 @@ test("StyletronServer toCss", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    ".a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.d{color:red}}@media (min-width: 800px){.c{color:green}.e:hover{color:green}}",
   );
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    ".a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.d{color:red}}@media (min-width: 800px){.c{color:green}.e:hover{color:green}}",
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getCss(),
-    "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    "@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}.a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.d{color:red}}@media (min-width: 800px){.c{color:green}.e:hover{color:green}}",
   );
   t.end();
 });
@@ -35,50 +35,50 @@ test("StyletronServer getStylesheets", t => {
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".d{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ag{color:green}.ai:hover{color:green}",
+      css: ".c{color:green}.e:hover{color:green}",
       attrs: {media: "(min-width: 800px)"},
     },
   ]);
   injectFixtureKeyframes(styletron);
   t.deepEqual(styletron.getStylesheets(), [
     {
-      css: "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
+      css: "@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}",
       attrs: {"data-hydrate": "keyframes"},
     },
     {
       css:
-        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".d{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ag{color:green}.ai:hover{color:green}",
+      css: ".c{color:green}.e:hover{color:green}",
       attrs: {media: "(min-width: 800px)"},
     },
   ]);
   injectFixtureFontFace(styletron);
   t.deepEqual(styletron.getStylesheets(), [
     {
-      css: "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}",
+      css: "@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}",
       attrs: {"data-hydrate": "keyframes"},
     },
     {
-      css: "@font-face{font-family:ae;src:local('Roboto')}",
+      css: "@font-face{font-family:a;src:local('Roboto')}",
       attrs: {"data-hydrate": "font-face"},
     },
     {
       css:
-        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".d{color:red}", attrs: {media: "(min-width: 600px)"}},
     {
-      css: ".ag{color:green}.ai:hover{color:green}",
+      css: ".c{color:green}.e:hover{color:green}",
       attrs: {media: "(min-width: 800px)"},
     },
   ]);
@@ -96,37 +96,37 @@ test("StyletronServer getStylesheetsHtml ", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_">.a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.d{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.c{color:green}.e:hover{color:green}</style>',
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_">.a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.d{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.c{color:green}.e:hover{color:green}</style>',
   );
   injectFixtureFontFace(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes a{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:a;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.a{color:red}.b{color:green}.f:hover{display:none}.g{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.h{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.d{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.c{color:green}.e:hover{color:green}</style>',
   );
   t.end();
 });
 
 test("StyletronServer prefix option", t => {
   const styletron = new Styletron({prefix: "foo_"});
-  t.equal(styletron.renderStyle({color: "red"}), "foo_ae");
-  t.equal(injectFixtureFontFace(styletron), "foo_ae");
-  t.equal(injectFixtureKeyframes(styletron), "foo_ae");
+  t.equal(styletron.renderStyle({color: "red"}), "foo_a");
+  t.equal(injectFixtureFontFace(styletron), "foo_a");
+  t.equal(injectFixtureKeyframes(styletron), "foo_a");
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        "@keyframes foo_ae{from{color:purple}50%{color:yellow}to{color:orange}}",
+        "@keyframes foo_a{from{color:purple}50%{color:yellow}to{color:orange}}",
       attrs: {"data-hydrate": "keyframes"},
     },
     {
-      css: "@font-face{font-family:foo_ae;src:local('Roboto')}",
+      css: "@font-face{font-family:foo_a;src:local('Roboto')}",
       attrs: {"data-hydrate": "font-face"},
     },
-    {css: ".foo_ae{color:red}", attrs: {}},
+    {css: ".foo_a{color:red}", attrs: {}},
   ]);
   t.end();
 });

--- a/packages/styletron-engine-snapshot/README.md
+++ b/packages/styletron-engine-snapshot/README.md
@@ -16,7 +16,7 @@ yarn add --dev styletron-engine-snapshot
 
 Snapshots generated with `styletron-engine-atomic` have 2 main issues
 
-1. non-debuggable classNames in snapshots (`"ae af "`)
+1. non-debuggable classNames in snapshots (`"a b c aa ab ac ae"`)
 
 2. className generation is dependent on internal engine state. If you create a new component,
 it might break an unrelated snapshot since that component rendering shifts the

--- a/packages/styletron-standard/src/__tests__/core.node.js
+++ b/packages/styletron-standard/src/__tests__/core.node.js
@@ -11,13 +11,13 @@ test("driver atomic", t => {
     color: "red",
   };
   driver(styleObject, instance);
-  cssString = ".ae{color:red}";
+  cssString = ".a{color:red}";
   t.strictEqual(instance.getCss(), cssString, "injects basic style");
   const fontFallback = {
     fontFamily: ["Arial", "sans-serif"],
   };
   driver(fontFallback, instance);
-  cssString = `${cssString}.af{font-family:Arial,sans-serif}`;
+  cssString = `${cssString}.b{font-family:Arial,sans-serif}`;
   t.strictEqual(instance.getCss(), cssString, "injects font fallbacks - basic");
   const fontFace = {
     src: "url(some-awesome-font.ttf)",
@@ -26,7 +26,7 @@ test("driver atomic", t => {
     fontFamily: [fontFace, "cursive"],
   };
   driver(declaredFontFaceFallback, instance);
-  cssString = `@font-face{font-family:ae;src:url(some-awesome-font.ttf)}${cssString}.ag{font-family:ae,cursive}`;
+  cssString = `@font-face{font-family:a;src:url(some-awesome-font.ttf)}${cssString}.c{font-family:a,cursive}`;
   t.strictEqual(
     instance.getCss(),
     cssString,


### PR DESCRIPTION
Previously the sequential id generator prevent `ad` from being generated by starting with `ae` (347). After the PR, the sequential id can also generate from `a` to `ac` (skip `ad`).

See also https://github.com/styletron/styletron/pull/219

cc @tajo @rtsao