### PR TITLE
Refactor: use stylis as prefixer

### DIFF
--- a/flow-typed/stylis.js
+++ b/flow-typed/stylis.js
@@ -1,0 +1,6 @@
+declare module "stylis" {
+  declare export function prefix(
+    cssDeclaration: string,
+    propertyLength: number,
+  ): string;
+}

--- a/packages/styletron-engine-atomic/package.json
+++ b/packages/styletron-engine-atomic/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "styletron-standard": "^3.0.5",
-    "stylis": "^4.0.13"
+    "stylis": "^4.1.0"
   },
   "devDependencies": {
     "create-universal-package": "3.2.4",

--- a/packages/styletron-engine-atomic/package.json
+++ b/packages/styletron-engine-atomic/package.json
@@ -30,8 +30,8 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "inline-style-prefixer": "^5.1.0",
-    "styletron-standard": "^3.0.5"
+    "styletron-standard": "^3.0.5",
+    "stylis": "^4.0.13"
   },
   "devDependencies": {
     "create-universal-package": "3.2.4",

--- a/packages/styletron-engine-atomic/src/inject-style-prefixed.js
+++ b/packages/styletron-engine-atomic/src/inject-style-prefixed.js
@@ -4,7 +4,8 @@ declare var __DEV__: boolean;
 
 import hyphenate from "./hyphenate-style-name.js";
 import {validateNoMixedHand} from "./validate-no-mixed-hand.js";
-import {prefix} from "inline-style-prefixer";
+
+import {prefix} from "stylis";
 
 import type {StyleObject} from "styletron-standard";
 
@@ -30,9 +31,9 @@ export default function injectStylePrefixed(
         validateValueType(originalVal, originalKey);
       }
 
-      const propValPair = `${hyphenate(
-        originalKey,
-      )}:${((originalVal: any): string)}`;
+      const hyphenatedProperty = hyphenate(originalKey);
+
+      const propValPair = `${hyphenatedProperty}:${((originalVal: any): string)}`;
       const key = `${pseudo}${propValPair}`;
       const cachedId = cache.cache[key];
       if (cachedId !== void 0) {
@@ -41,27 +42,12 @@ export default function injectStylePrefixed(
         continue;
       } else {
         // cache miss
-        let block = "";
-        const prefixed = prefix({[originalKey]: originalVal});
-        for (const prefixedKey in prefixed) {
-          const prefixedVal = prefixed[prefixedKey];
-          const prefixedValType = typeof prefixedVal;
-          if (prefixedValType === "string" || prefixedValType === "number") {
-            const prefixedPair = `${hyphenate(prefixedKey)}:${prefixedVal}`;
-            if (prefixedPair !== propValPair) {
-              block += `${prefixedPair};`;
-            }
-          } else if (Array.isArray(prefixedVal)) {
-            const hyphenated = hyphenate(prefixedKey);
-            for (let i = 0; i < prefixedVal.length; i++) {
-              const prefixedPair = `${hyphenated}:${prefixedVal[i]}`;
-              if (prefixedPair !== propValPair) {
-                block += `${prefixedPair};`;
-              }
-            }
-          }
-        }
-        block += propValPair; // ensure original prop/val is last (for hydration)
+        const cssDeclaration = `${hyphenatedProperty}:${((originalVal: any): string)};`;
+        const prefixed = prefix(cssDeclaration, hyphenatedProperty.length);
+        const block =
+          prefixed[prefixed.length - 1] === ";"
+            ? prefixed.slice(0, -1)
+            : prefixed;
         const id = cache.addValue(key, {pseudo, block});
         classString += " " + id;
       }

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.js
@@ -9,17 +9,17 @@ test("StyletronServer toCss", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getCss(),
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getCss(),
-    "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
   t.end();
 });
@@ -35,7 +35,7 @@ test("StyletronServer getStylesheets", t => {
   t.deepEqual(styletron.getStylesheets(), [
     {
       css:
-        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}",
       attrs: {},
     },
     {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
@@ -52,7 +52,7 @@ test("StyletronServer getStylesheets", t => {
     },
     {
       css:
-        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}",
       attrs: {},
     },
     {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
@@ -73,7 +73,7 @@ test("StyletronServer getStylesheets", t => {
     },
     {
       css:
-        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+        ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}",
       attrs: {},
     },
     {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
@@ -96,17 +96,17 @@ test("StyletronServer getStylesheetsHtml ", t => {
   injectFixtureStyles(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
   injectFixtureKeyframes(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
   injectFixtureFontFace(styletron);
   t.equal(
     styletron.getStylesheetsHtml(),
-    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
   t.end();
 });

--- a/packages/styletron-engine-monolithic/package.json
+++ b/packages/styletron-engine-monolithic/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "styletron-standard": "^3.0.5",
-    "stylis": "^4.0.13"
+    "stylis": "^4.1.0"
   },
   "devDependencies": {
     "create-universal-package": "3.2.4",

--- a/packages/styletron-engine-monolithic/package.json
+++ b/packages/styletron-engine-monolithic/package.json
@@ -30,8 +30,8 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "inline-style-prefixer": "^5.1.0",
-    "styletron-standard": "^3.0.5"
+    "styletron-standard": "^3.0.5",
+    "stylis": "^4.0.13"
   },
   "devDependencies": {
     "create-universal-package": "3.2.4",

--- a/packages/styletron-engine-monolithic/src/inject-style-prefixed.js
+++ b/packages/styletron-engine-monolithic/src/inject-style-prefixed.js
@@ -4,7 +4,7 @@ declare var __DEV__: boolean;
 
 import hyphenate from "./hyphenate-style-name.js";
 import {validateNoMixedHand} from "./validate-no-mixed-hand.js";
-import {prefix as prefixRule} from "inline-style-prefixer";
+import {prefix as prefixCssDeclaration} from "stylis";
 
 import type {StyleObject} from "styletron-standard";
 
@@ -39,29 +39,16 @@ export default function injectStylePrefixed(
         }
       }
 
-      const rule = hyphenate(key) + ":" + value;
-      const prefixed = prefixRule({[key]: value});
-      for (const prefixedKey in prefixed) {
-        const prefixedVal = prefixed[prefixedKey];
-        if (
-          typeof prefixedVal === "string" ||
-          typeof prefixedVal === "number"
-        ) {
-          const prefixedRule = hyphenate(prefixedKey) + ":" + prefixedVal;
-          if (prefixedRule !== rule) {
-            rules += prefixedRule + ";";
-          }
-        } else if (Array.isArray(prefixedVal)) {
-          const hyphenated = hyphenate(prefixedKey);
-          for (let i = 0; i < prefixedVal.length; i++) {
-            const prefixedRule = hyphenated + ":" + prefixedVal[i];
-            if (prefixedRule !== rule) {
-              rules += prefixedRule + ";";
-            }
-          }
-        }
+      const hyphenatedProperty = hyphenate(key);
+      const cssDeclaration = hyphenatedProperty + ":" + value + ";";
+      const prefixed = prefixCssDeclaration(
+        cssDeclaration,
+        hyphenatedProperty.length,
+      );
+      rules += prefixed;
+      if (prefixed[prefixed.length - 1] !== ";") {
+        rules += ";";
       }
-      rules += rule + ";";
       continue;
     }
 

--- a/packages/styletron-standard/package.json
+++ b/packages/styletron-standard/package.json
@@ -30,8 +30,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@rtsao/csstype": "2.6.5-forked.0",
-    "inline-style-prefixer": "^5.1.0"
+    "@rtsao/csstype": "2.6.5-forked.0"
   },
   "devDependencies": {
     "create-universal-package": "3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9206,10 +9206,10 @@ stylis@3.5.4:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
-stylis@^4.0.13:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
-  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
+stylis@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.0.tgz#e3c7b24ff96d8af35efd161b6991a81c46e51933"
+  integrity sha512-SrSDzNasOCBTo7C2N9geFwydg/2bmdkWXd4gJirtq82m5JBYtR2+Ialck8czmfBLIdPxCOotlgJESPa8C1RqvA==
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,14 +3574,6 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
-  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
-
 css-loader@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.2.0.tgz#bb570d89c194f763627fcf1f80059c6832d009b2"
@@ -5238,11 +5230,6 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-hyphenate-style-name@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-  integrity sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=
-
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -5385,13 +5372,6 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
   integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
-
-inline-style-prefixer@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz#cb63195f9456dcda25cf59743e45c4d9815b0811"
-  integrity sha512-giteQHPMrApQOSjNSjteO5ZGSGMRf9gas14fRy2lg2buSc1nRnj6o6xuNds5cMTKrkncyrTu3gJn/yflFMVdmg==
-  dependencies:
-    css-in-js-utils "^2.0.0"
 
 inquirer@^3.2.2:
   version "3.3.0"
@@ -9225,6 +9205,11 @@ stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
+stylis@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Recently, Robin Weser, the author of `inline-style-prefixer`, who is also the author of [Fela Atomic CSS-in-JS library](https://fela.js.org), has changed the Fela's CSS prefixer to [stylis](https://github.com/thysultan/stylis), an extremely lightweight CSS preprocessor that is also used by [emotion Monolithic CSS-in-JS library](https://emotion.sh).

By changing from `inline-style-prefixer` to `stylis`:

- The bundle size can be reduced, as stylis is very lightweight and fast (take a look at [how stylis' prefixer is implemented](https://github.com/thysultan/stylis/blob/master/src/Prefixer.js))
- stylis support a wider range of browsers without sacrificing the bundle size
- stylis' `prefix` function take in a string of CSS declaration and the length of the hyphenated property and return a string of prefixed CSS declaration string, which makes the code clean and fast (Previously, styletron has to make an adapter that creates a `StyleObject` for `inline-style-prefixer` from a string, and build a CSS declaration string from the returned prefixed `StyleObject` outputs)

----

~~Note: The PR is marked as a draft since stylis hasn't brought up the grid support (https://github.com/thysultan/stylis/pull/285). I will update the test case when the PR is merged and a new version of stylis is released.~~