### PR TITLE
export StyletronComponent flow type

### DIFF
--- a/packages/styletron-react/src/index.js.flow
+++ b/packages/styletron-react/src/index.js.flow
@@ -51,7 +51,7 @@ type Styletron = {
 
 type ExtractPropTypes = <T>(StyletronComponent<T>) => T;
 
-type StyletronComponent<Props> = StatelessFunctionalComponent<Props> & {
+export type StyletronComponent<Props> = StatelessFunctionalComponent<Props> & {
   __STYLETRON__: any,
 };
 


### PR DESCRIPTION
adding export to `StyletronComponent` flow type which happens to be imported directly from `src/types` by some users of older styletron-react versions