### PR TITLE
update WithWrapperFn type declaration

### DIFF
--- a/packages/styletron-react/src/types.ts
+++ b/packages/styletron-react/src/types.ts
@@ -104,7 +104,9 @@ export type WithTransformFn = <
 
 export type WithWrapperFn = <Base extends StyletronComponent<any, any>, Props>(
   component: Base,
-  wrapper: (component: Base) => ComponentType<Props>,
+  wrapper: (
+    component: Base,
+  ) => ComponentType<Props & React.ComponentProps<Base>>,
 ) => Base extends StyletronComponent<infer D, infer P>
   ? StyletronComponent<D, P & Props>
   : never;


### PR DESCRIPTION
updating `WithWrapperFn` to by default also include props from wrapped component which looks to be a common use-case