### PR TITLE
Fix Type 'Props' does not satisfy the constraint '{}'

### DIFF
--- a/packages/styletron-react/src/types.ts
+++ b/packages/styletron-react/src/types.ts
@@ -77,7 +77,7 @@ export interface StyletronComponent<D extends React.ElementType, P extends {}> {
 }
 
 export type StyledFn = {
-  <T extends React.ElementType, Props>(
+  <T extends React.ElementType, Props extends {}>(
     component: T,
     style: StyleObject | ((props: Props) => StyleObject),
   ): StyletronComponent<T, Props>;


### PR DESCRIPTION
This is to fix an issue with [Typing errors](https://github.com/styletron/styletron/issues/431)