### PR TITLE
Add @container query support

### DIFF
--- a/packages/styletron-engine-atomic/src/client/__tests__/client.browser.ts
+++ b/packages/styletron-engine-atomic/src/client/__tests__/client.browser.ts
@@ -233,6 +233,23 @@ function injectFixtureStyles(styletron) {
     },
   });
   styletron.renderStyle({
+    "@container (min-width: 800px)": {
+      color: "yellow",
+    },
+  });
+  styletron.renderStyle({
+    "@container (min-width: 600px)": {
+      color: "blue",
+    },
+  });
+  styletron.renderStyle({
+    "@container (min-width: 800px)": {
+      ":hover": {
+        color: "yellow",
+      },
+    },
+  });
+  styletron.renderStyle({
     ":hover": {
       display: "none",
     },

--- a/packages/styletron-engine-atomic/src/inject-style-prefixed.ts
+++ b/packages/styletron-engine-atomic/src/inject-style-prefixed.ts
@@ -77,13 +77,16 @@ export default function injectStylePrefixed(
             media,
             pseudo + originalKey,
           );
-      } else if (originalKey.substring(0, 6) === "@media") {
+      } else if (
+        originalKey.substring(0, 6) === "@media" ||
+        originalKey.substring(0, 10) === "@container"
+      ) {
         classString +=
           " " +
           injectStylePrefixed(
             styleCache,
             originalVal as StyleObject,
-            originalKey.substr(7),
+            originalKey,
             pseudo,
           );
       }

--- a/packages/styletron-engine-atomic/src/server/__tests__/tests.node.ts
+++ b/packages/styletron-engine-atomic/src/server/__tests__/tests.node.ts
@@ -6,17 +6,17 @@ test("StyletronServer toCss", () => {
 
   injectFixtureStyles(styletron);
   expect(styletron.getCss()).toBe(
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@container (min-width: 600px){.ak{color:blue}}@media (min-width: 600px){.ah{color:red}}@container (min-width: 800px){.aj{color:yellow}.al:hover{color:yellow}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
 
   injectFixtureStyles(styletron);
   expect(styletron.getCss()).toBe(
-    ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    ".ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@container (min-width: 600px){.ak{color:blue}}@media (min-width: 600px){.ah{color:red}}@container (min-width: 800px){.aj{color:yellow}.al:hover{color:yellow}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
 
   injectFixtureKeyframes(styletron);
   expect(styletron.getCss()).toBe(
-    "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@media (min-width: 600px){.ah{color:red}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
+    "@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}.ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}@container (min-width: 600px){.ak{color:blue}}@media (min-width: 600px){.ah{color:red}}@container (min-width: 800px){.aj{color:yellow}.al:hover{color:yellow}}@media (min-width: 800px){.ag{color:green}.ai:hover{color:green}}",
   );
 });
 
@@ -27,13 +27,18 @@ test("StyletronServer getStylesheets", () => {
   injectFixtureStyles(styletron);
   expect(styletron.getStylesheets()).toEqual([
     {
-      css: ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+      css: ".ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".ak{color:blue}", attrs: {media: "@container (min-width: 600px)"}},
+    {css: ".ah{color:red}", attrs: {media: "@media (min-width: 600px)"}},
+    {
+      css: ".aj{color:yellow}.al:hover{color:yellow}",
+      attrs: {media: "@container (min-width: 800px)"},
+    },
     {
       css: ".ag{color:green}.ai:hover{color:green}",
-      attrs: {media: "(min-width: 800px)"},
+      attrs: {media: "@media (min-width: 800px)"},
     },
   ]);
 
@@ -44,13 +49,18 @@ test("StyletronServer getStylesheets", () => {
       attrs: {"data-hydrate": "keyframes"},
     },
     {
-      css: ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+      css: ".ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".ak{color:blue}", attrs: {media: "@container (min-width: 600px)"}},
+    {css: ".ah{color:red}", attrs: {media: "@media (min-width: 600px)"}},
+    {
+      css: ".aj{color:yellow}.al:hover{color:yellow}",
+      attrs: {media: "@container (min-width: 800px)"},
+    },
     {
       css: ".ag{color:green}.ai:hover{color:green}",
-      attrs: {media: "(min-width: 800px)"},
+      attrs: {media: "@media (min-width: 800px)"},
     },
   ]);
 
@@ -65,13 +75,18 @@ test("StyletronServer getStylesheets", () => {
       attrs: {"data-hydrate": "font-face"},
     },
     {
-      css: ".ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
+      css: ".ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}",
       attrs: {},
     },
-    {css: ".ah{color:red}", attrs: {media: "(min-width: 600px)"}},
+    {css: ".ak{color:blue}", attrs: {media: "@container (min-width: 600px)"}},
+    {css: ".ah{color:red}", attrs: {media: "@media (min-width: 600px)"}},
+    {
+      css: ".aj{color:yellow}.al:hover{color:yellow}",
+      attrs: {media: "@container (min-width: 800px)"},
+    },
     {
       css: ".ag{color:green}.ai:hover{color:green}",
-      attrs: {media: "(min-width: 800px)"},
+      attrs: {media: "@media (min-width: 800px)"},
     },
   ]);
 });
@@ -84,17 +99,17 @@ test("StyletronServer getStylesheetsHtml ", () => {
 
   injectFixtureStyles(styletron);
   expect(styletron.getStylesheetsHtml()).toBe(
-    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="@container (min-width: 600px)">.ak{color:blue}</style><style class="_styletron_hydrate_" media="@media (min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="@container (min-width: 800px)">.aj{color:yellow}.al:hover{color:yellow}</style><style class="_styletron_hydrate_" media="@media (min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
 
   injectFixtureKeyframes(styletron);
   expect(styletron.getStylesheetsHtml()).toBe(
-    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="@container (min-width: 600px)">.ak{color:blue}</style><style class="_styletron_hydrate_" media="@media (min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="@container (min-width: 800px)">.aj{color:yellow}.al:hover{color:yellow}</style><style class="_styletron_hydrate_" media="@media (min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
 
   injectFixtureFontFace(styletron);
   expect(styletron.getStylesheetsHtml()).toBe(
-    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.aj:hover{display:none}.ak{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.al{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="(min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="(min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
+    '<style class="_styletron_hydrate_" data-hydrate="keyframes">@keyframes ae{from{color:purple}50%{color:yellow}to{color:orange}}</style><style class="_styletron_hydrate_" data-hydrate="font-face">@font-face{font-family:ae;src:local(\'Roboto\')}</style><style class="_styletron_hydrate_">.ae{color:red}.af{color:green}.am:hover{display:none}.an{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.ao{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex}</style><style class="_styletron_hydrate_" media="@container (min-width: 600px)">.ak{color:blue}</style><style class="_styletron_hydrate_" media="@media (min-width: 600px)">.ah{color:red}</style><style class="_styletron_hydrate_" media="@container (min-width: 800px)">.aj{color:yellow}.al:hover{color:yellow}</style><style class="_styletron_hydrate_" media="@media (min-width: 800px)">.ag{color:green}.ai:hover{color:green}</style>',
   );
 });
 
@@ -137,6 +152,25 @@ function injectFixtureStyles(styletron) {
     "@media (min-width: 800px)": {
       ":hover": {
         color: "green",
+      },
+    },
+  });
+  styletron.renderStyle({
+    "@container (min-width: 800px)": {
+      color: "yellow",
+    },
+  });
+  // should be added before "min-width: 800px" query
+  // test that Styletron properly sort container queries
+  styletron.renderStyle({
+    "@container (min-width: 600px)": {
+      color: "blue",
+    },
+  });
+  styletron.renderStyle({
+    "@container (min-width: 800px)": {
+      ":hover": {
+        color: "yellow",
       },
     },
   });

--- a/packages/styletron-engine-atomic/src/server/server.ts
+++ b/packages/styletron-engine-atomic/src/server/server.ts
@@ -171,7 +171,7 @@ function stringify(styleRules, sortedCacheKeys) {
   sortedCacheKeys.forEach(cacheKey => {
     const rules = styleRules[cacheKey];
     if (cacheKey !== "") {
-      result += `@media ${cacheKey}{${rules}}`;
+      result += `${cacheKey}{${rules}}`;
     } else {
       result += rules;
     }

--- a/packages/styletron-engine-snapshot/src/__tests__/index.test.ts
+++ b/packages/styletron-engine-snapshot/src/__tests__/index.test.ts
@@ -29,6 +29,14 @@ test("StyletronSnapshotEngine rendering", () => {
   );
 
   expect(
+    instance.renderStyle({
+      "@container (min-width: 600px)": {color: "purple"},
+    }),
+  ).toBe(
+    "style={\n  '@container (min-width: 600px)': {\n    color: 'purple',\n  },\n}\n",
+  );
+
+  expect(
     instance.renderFontFace({
       src: "local('Roboto')",
     }),


### PR DESCRIPTION
Addresses: https://github.com/styletron/styletron/issues/436

@container queries started landing in stable browsers about a year ago and have been fully supported across all major browsers for over 6 months now. I had a use case where they will be very useful and I wanted to use them with Styletron.